### PR TITLE
Integration with the Wayback Machine's Site Search (through the omnibox, showing suggestions)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,5 +27,11 @@
   "browser_action": {
    "default_icon": "images/icon.png",
    "default_popup": "index.html"
+  },
+  "omnibox": {
+    "keyword": "wm"
+  },
+  "icons": {
+    "32": "images/icon.png"
   }
 }

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -420,3 +420,59 @@ chrome.runtime.onMessage.addListener(function(message,sender,sendResponse){
   }
 });
 
+
+// Integration with the Wayback Machine search (showing suggestions)
+// Type in the omnibox "wm [TAB or space] [search query]"
+
+var currReq = null;
+
+chrome.omnibox.onInputChanged.addListener(function(txt, sugg) {
+  if (currReq != null) {
+    currReq.onreadystatechange = null;
+    currReq.abort();
+    currReq = null;
+  }
+  updateDefSugg(txt);
+
+  if (txt.length > 0) {
+    var currReq = getSugg(txt, function(data) {
+      if (data['hosts'].length >= 5) {
+        var hosts = [];
+        for (var i = 0; i < 5; i++) {
+          hosts.push({
+            content: data['hosts'][i]['display_name'],
+            description: data['hosts'][i]['display_name']
+          });
+        }
+        sugg(hosts);
+      }
+    });
+  }
+});
+
+function getSugg(key, callback) {
+  var req = new XMLHttpRequest();
+  req.onreadystatechange = function() {
+    if (this.readyState == 4 && this.status == 200) {
+      callback(JSON.parse(this.responseText));
+    }
+  };
+  req.open('GET', 'https://web-beta.archive.org/__wb/search/host?q=' + key, true);
+  req.send();
+};
+
+function resetDefSugg() {
+  chrome.omnibox.setDefaultSuggestion({ description: ' ' });
+};
+
+function updateDefSugg(txt) {
+  chrome.omnibox.setDefaultSuggestion({ description: 'Search: %s' });
+};
+
+chrome.omnibox.onInputStarted.addListener(function() { updateDefSugg(''); });
+
+chrome.omnibox.onInputCancelled.addListener(function() { resetDefSugg(); });
+
+chrome.omnibox.onInputEntered.addListener(function(txt) {
+  chrome.tabs.update(null, { url: 'https://web-beta.archive.org/web/*/' + txt });
+});


### PR DESCRIPTION
This pull request adds integration with the Wayback Machine's Site Search through the omnibox (**showing suggestions**), simply by typing "wm [TAB or space] [search query]".

Here you can see this feature in operation by looking for "google".

![search_sample](https://cloud.githubusercontent.com/assets/12954316/24433798/780db5e2-142b-11e7-99d7-a55c5582baf4.png)

Any feedback is more than welcome!