### PR TITLE
charachter reference terminated by semi-colon

### DIFF
--- a/scripts/RTcontent.js
+++ b/scripts/RTcontent.js
@@ -27,7 +27,7 @@ if(document.getElementById('myModal') !== null) {
   message.setAttribute('id','message');
   **/
   var span=document.createElement('button');
-  span.innerHTML='&times';
+  span.innerHTML='&times;';
   span.setAttribute('class','RTclose');
   modal.appendChild(span);
   /**


### PR DESCRIPTION
Named charachter reference terminated by semi-colon
file : RTcontent.js
line no 30.

fixes: #97 