### PR TITLE
Don’t show extension context menu where it is not archivable

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -483,24 +483,28 @@ chrome.webRequest.onErrorOccurred.addListener(function(details) {
 var contextMenuItemFirst={
     "id":"first",
     "title":"First Version",
-    "contexts":["all"]
+    "contexts":["all"],
+    "documentUrlPatterns":["*://*/*", "ftp://*/*"]
 };
 
 var contextMenuItemRecent={
     "id":"recent",
     "title":"Recent Version",
-    "contexts":["all"]
+    "contexts":["all"],
+    "documentUrlPatterns":["*://*/*", "ftp://*/*"]
 };
 var contextMenuItemAll={
     "id":"all",
     "title":"All Versions",
-    "contexts":["all"]
+    "contexts":["all"],
+    "documentUrlPatterns":["*://*/*", "ftp://*/*"]
 };
 
 var contextMenuItemSave={
     "id":"save",
     "title":"Save Page Now",
-    "contexts":["all"]
+    "contexts":["all"],
+    "documentUrlPatterns":["*://*/*", "ftp://*/*"]
 };
 chrome.contextMenus.create(contextMenuItemFirst);
 chrome.contextMenus.create(contextMenuItemRecent);


### PR DESCRIPTION
Currently "Wayback Machine" context menu appears on all pages, including Chrome Extensions page (chrome://extensions) and browser action popup.

While context menu on browser action popup works OK, it looks out-of-place. It is not useful at all to show context menus items like "First Version" on Chrome Extensions page.

This patch adds `documentUrlPatterns` option to each of menu items, to show them on http, https and ftp URLs only. Browser action button context menu still has all extension menu items, even when active tab is Chrome Extensions page.

Menu item description is getting a bit verbose -- I leave it for another edit to clean them up.