### PR TITLE
changed 503 interception

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Wayback Machine",
   "description": "Reduce annoying 404 pages by automatically checking for an archived copy in the Wayback Machine.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "homepage_url": "https://archive.org/",
   "icons": {
     "48": "images/icon.png",


### PR DESCRIPTION
503, 504 etc when intercepted led to a small notification on the bottom right of the screen. This is because client.js cannot be injected into such pages. This commit makes the tab re-direct to dnserror.html on interception of 503 , 504 etc
@vbanos please check it out