### PR TITLE
Fixed 503 interception

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Wayback Machine",
   "description": "Reduce annoying 404 pages by automatically checking for an archived copy in the Wayback Machine.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "homepage_url": "https://archive.org/",
   "icons": {
     "48": "images/icon.png",

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -83,7 +83,7 @@ chrome.webRequest.onCompleted.addListener(function(details) {
                     chrome.tabs.executeScript(details.tabId, {
                     file: "scripts/client.js"
                     },function() {
-                        if(chrome.runtime.lastError.message.startsWith('Cannot access contents of url "chrome-error://chromewebdata/')){
+                        if(chrome.runtime.lastError && chrome.runtime.lastError.message.startsWith('Cannot access contents of url "chrome-error://chromewebdata/')){
                             chrome.tabs.update(details.tabId, {url: chrome.extension.getURL('dnserror.html')+"?wayback_url="+wayback_url+"?page_url="+url+"?status_code="+details.statusCode+"?"});
                         }else{
                             chrome.tabs.sendMessage(details.tabId, {


### PR DESCRIPTION
The try catch block was not working because the error was not being thrown. The error is stored in `chrome.runtime.lastError`. I checked for this inside the callback for `chrome.tabs.executeScript()` and if it is set to `Cannot access contents of url "chrome-error://chromewebdata/` then I displayed dnserror.html.