### PR TITLE
DOI links feature

### DIFF
--- a/css/doi.css
+++ b/css/doi.css
@@ -1,0 +1,101 @@
+body{
+    max-height: 100%;
+}
+@font-face {
+    font-family: Bebas Neue;
+    src: url("../fonts/BebasNeue.otf");
+}
+
+@font-face {
+    font-family: Gill Sans Light;
+    src: url("../fonts/GillSans-Light.ttf");
+}
+
+.container{
+    background: white;
+    padding-left: 15px;
+    padding-right: 15px;
+    margin-left: auto;
+    margin-right: auto;
+}
+p{
+    font-family:Gill Sans Light;
+    font-size: 20px;
+}
+.box{
+    border:1px solid black;
+    border-radius: 5px;
+    box-shadow: 0px 1px 1px 0px rgba(0,0,0,0.1);
+/*
+    display: flex;
+    flex :0 0 420px;
+    flex-direction: column;
+    justify-content: center;
+*/
+    margin-bottom: 12px;
+    overflow: hidden;
+    padding: 5px 5px 5px 5px;
+}
+.target-selector-exact{
+    font-family:'Courier New', Courier, monospace;
+    word-wrap: break-word;
+}
+#link-incontext{
+    margin-left:40px; 
+}
+#link-html{
+    margin-left: 70px;
+}
+#date{
+    position: absolute;
+    right: 20px;
+}
+.source{
+    padding: 5px;
+}
+#text-contain{
+    padding: 5px;
+}
+#target-selector-exact-contain{
+    border-left: 3px solid #d3d3d3;
+    color: #7A7A7A;
+    padding: 5px;
+}
+#target-selector-exact-contain:hover{
+    border-left: 3px solid #58CEF4;
+}
+#links{
+    padding: 10px;
+}
+.extra_margin{
+    margin-top:3px
+}
+.lower_margin{
+    margin-bottom: 5px;
+}
+.row_main{
+    align-items: stretch;
+    display: flex;
+    justify-content: center;
+}
+.half{
+    width: 600px;
+}
+#source-contain{
+    word-wrap: break-word;
+}
+#title-contain{
+    color: red;
+}
+.public_on{
+    color: #818181;
+    font-weight: 150%;
+}
+@media screen and (max-width: 500px) {
+    #link-incontext {
+      margin-left: 5px;
+    }
+    #link-html{
+        margin-left: 10px;
+    }
+}

--- a/css/singleWindow.css
+++ b/css/singleWindow.css
@@ -39,6 +39,20 @@ p{
         text-align: center;
     }
 }
+.box{
+    border:1px solid black;
+    border-radius: 5px;
+    box-shadow: 0px 1px 1px 0px rgba(0,0,0,0.1);
+/*
+    display: flex;
+    flex :0 0 420px;
+    flex-direction: column;
+    justify-content: center;
+*/
+    margin-bottom: 12px;
+    overflow: hidden;
+    padding: 5px 5px 5px 5px;
+}
 .box-annotation{
     margin-bottom: 12px;
     flex :0 0 420px;
@@ -84,7 +98,17 @@ p{
 #links{
     padding: 10px;
 }
-
+.row_main{
+    align-items: stretch;
+    display: flex;
+    justify-content: center;
+}
+.half{
+    width: 600px;
+}
+#doi-heading{
+    display: none;
+}
 @media screen and (max-width: 500px) {
     #link-incontext {
       margin-left: 5px;

--- a/doi.html
+++ b/doi.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="css/font-awesome.min.css">
         <script src="scripts/doi.js"></script>
         <title>
-            Scientific Papers
+            Scientific Publications
         </title>
     </head>
     <body>

--- a/doi.html
+++ b/doi.html
@@ -1,0 +1,33 @@
+<html>
+    <head>
+        <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+        <meta content="utf-8" http-equiv="encoding">
+        <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
+        <link rel="stylesheet" type="text/css" href="css/doi.css">
+        <link rel="stylesheet" type="text/css" href="css/common.css">
+        <link rel="stylesheet" type="text/css" href="css/font-awesome.min.css">
+        <script src="scripts/doi.js"></script>
+        <title>
+            Scientific Papers
+        </title>
+    </head>
+    <body>
+        <table width="100%" style="max-height: 200px;">
+            <tr class="spaceUnder">
+                <td style="text-align: center;">
+                    <div id ="horizontal_line" class="lower_margin"></div>
+                        <div class='container'>
+                            <img class='resize_fit_center'
+                            src='images/logo.gif' />
+                        </div>
+                    <div id="horizontal_line" class="extra_margin"></div>
+                </td>
+            </tr>
+        </table>
+        <div class="text-center">
+            <h2><strong id="doi-heading">Current Wikipedia Page Scientific Publications</strong></h2>
+        </div>
+        <div class="container-fluid" id="container-whole">
+        </div>
+    </body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Wayback Machine",
   "description": "Reduce annoying 404 pages by automatically checking for an archived copy in the Wayback Machine.",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "homepage_url": "https://archive.org/",
   "icons": {
     "48": "images/icon.png",

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -24,6 +24,7 @@ var windowId6=0;
 var windowId7=0;
 var windowId8=0;
 var windowId9=0;
+var windowId10=0;
 var windowIdtest=0;
 var tabId1=0;
 //Tab Id of the Context-tabs
@@ -35,6 +36,7 @@ var tabId6=0;
 var tabId7=0;
 var tabId8=0;
 var tabId9=0;
+var tabId10=0;
 var windowIdSingle=0;
 var WB_API_URL = "https://archive.org/wayback/available";
 
@@ -281,12 +283,20 @@ chrome.runtime.onMessage.addListener(function(message,sender,sendResponse){
                     }
                     //If show-all Context is true, Create a window which is focussed and create tabs in it
                     if(event2.showall==true){
-                      var alexa_url="https://archive.org/services/context/alexa?url="+url;
-                      chrome.windows.create({url:alexa_url, width:800, height:800, top:0, left:0, focused:true},function (win) {
-                        windowIdtest = win.id;
+                      chrome.windows.create({url:chrome.runtime.getURL("doi.html")+"?url="+message.url, width:800, height:800, top:0, left:0, focused:true},function(win){
+                        windowIdtest=win.id;
                         chrome.windows.onRemoved.addListener(function (win1) {
-                          if(win1==windowIdtest){
-                            windowIdtest=0;
+                            if(win1==windowIdtest){
+                                windowIdtest=0;
+                            }
+                        });
+                      });
+                      var alexa_url="https://archive.org/services/context/alexa?url="+url;
+                      chrome.tabs.create({url:alexa_url, 'active':false},function (tab) {
+                        tabId10 = tab.id;
+                        chrome.tabs.onRemoved.addListener(function (tabtest) {
+                          if(tabtest==tabId10){
+                            tabId10=0;
                           }
                         });
                       });
@@ -359,6 +369,12 @@ chrome.runtime.onMessage.addListener(function(message,sender,sendResponse){
                       });
                     }else{
                       //If not selected show-all option ,then check and open indivisually
+                    chrome.storage.sync.get(function(event13){
+                      if(event13.doi==true){
+                        console.log("Checking doi");
+                        console.log(message.url);
+                        openThatContext("doi",message.url,event.show_context);
+                      }
                       chrome.storage.sync.get(function(event4){
                         if(event4.alexa==true){
                           console.log("checking alexa");
@@ -413,6 +429,7 @@ chrome.runtime.onMessage.addListener(function(message,sender,sendResponse){
                               });
                           });
                       });
+                    });
                     }
                   });
                 }else{
@@ -421,9 +438,11 @@ chrome.runtime.onMessage.addListener(function(message,sender,sendResponse){
                     windowId: windowIdtest
                   }, function(tabs) {
                     var tab=tabs[0];
-                    var alexa_url="https://archive.org/services/context/alexa?url="+url;
+                    chrome.tabs.update(tab.id, {url:chrome.runtime.getURL("doi.html")+"?url="+message.url});
                     chrome.tabs.update(tab.id, {url:alexa_url});
                   });
+                  var alexa_url="https://archive.org/services/context/alexa?url="+url;
+                  chrome.tabs.update(parseInt(tabId10), {url:alexa_url});
                   var whois_url="https://archive.org/services/context/whois?url=" + url;
                   chrome.tabs.update(parseInt(tabId2), {url:whois_url});
                   var tweet_url="https://archive.org/services/context/twitter?url="+open_url;
@@ -438,7 +457,7 @@ chrome.runtime.onMessage.addListener(function(message,sender,sendResponse){
                 }
               }else if(event.show_context=="window"){  
                 //If the Context is to be showed in Windows 
-                if(windowId1==0 ||windowId2==0||windowId3==0||windowId4==0||windowId5==0||windowId6==0 ||windowId7==0 ||windowId8 ==0 ||windowId9==0){
+                if(windowId1==0 ||windowId2==0||windowId3==0||windowId4==0||windowId5==0||windowId6==0 ||windowId7==0 ||windowId8 ==0 ||windowId9==0 || windowId10==0){
                   //Checking if Windows are not open already
                   chrome.storage.sync.get(['showall'],function(event2){
                     if(event2.showall==undefined){
@@ -446,12 +465,20 @@ chrome.runtime.onMessage.addListener(function(message,sender,sendResponse){
                     }
                     if(event2.showall==true){
                       //If show-all Context is true, create a context windows 
-                      var alexa_url="https://archive.org/services/context/alexa?url="+url;
-                      chrome.windows.create({url:alexa_url, width:500, height:500, top:0, left:0, focused:false},function (win) {
+                      chrome.windows.create({url:chrome.runtime.getURL("doi.html")+"?url="+message.url,width:600, height:500, top:600, left:1100, focused:false},function (win) {
                         windowId1 = win.id;
                         chrome.windows.onRemoved.addListener(function (win1) {
                           if(win1==windowId1){
                             windowId1=0;
+                          }
+                        });
+                      });
+                      var alexa_url="https://archive.org/services/context/alexa?url="+url;
+                      chrome.windows.create({url:alexa_url, width:500, height:500, top:0, left:0, focused:false},function (win) {
+                        windowId10 = win.id;
+                        chrome.windows.onRemoved.addListener(function (win1) {
+                          if(win1==windowId10){
+                            windowId10=0;
                           }
                         });
                       });
@@ -524,6 +551,10 @@ chrome.runtime.onMessage.addListener(function(message,sender,sendResponse){
                       });
                     }else{
                       //If not selected show-all option ,then check and open indivisually 
+                     chrome.storage.sync.get(function(event13){
+                        if(event13.doi==true){
+                            openThatContext("doi",message.url,event.show_context);
+                        }
                       chrome.storage.sync.get(function(event4){
                         if(event4.alexa==true){
                           openThatContext("alexa",url,event.show_context);
@@ -560,6 +591,7 @@ chrome.runtime.onMessage.addListener(function(message,sender,sendResponse){
                                                     if(event12.hoaxy==true){
                                                       openThatContext("hoaxy",open_url,event.show_context);
                                                     }
+                                                  });
                                                   });
                                               });
                                             });
@@ -630,6 +662,12 @@ chrome.runtime.onMessage.addListener(function(message,sender,sendResponse){
                     var tab=tabs[0];
                     var hoaxy_url="http://hoaxy.iuni.iu.edu/#query="+open_url+"&sort=mixed&type=Twitter";
                     chrome.tabs.update(tab.id, {url:hoaxy_url});
+                  });
+                  chrome.tabs.query({
+                    windowId: windowId10
+                  }, function(tabs) {
+                    var tab=tabs[0];
+                    chrome.tabs.update(tab.id, {url:chrome.runtime.getURL("doi.html")+"?url="+message.url});
                   });
                 }                               
               }
@@ -835,7 +873,7 @@ chrome.contextMenus.onClicked.addListener(function(clickedData){
 //   }
 // });
 // }
-var tabIdAlexa,tabIdWhois,tabIdtwit,tabIdoverview,tabIdannotation,tabIdtest,tabIdsimilarweb,tabIdtagcloud,tabIdannotationurl,tabIdhoaxy; 
+var tabIdAlexa,tabIdWhois,tabIdtwit,tabIdoverview,tabIdannotation,tabIdtest,tabIdsimilarweb,tabIdtagcloud,tabIdannotationurl,tabIdhoaxy,tabIddoi; 
 chrome.tabs.onUpdated.addListener(function(tabId, info) {
   if (info.status == "complete") { 
     chrome.tabs.get(tabId, function(tab) {
@@ -870,7 +908,7 @@ chrome.tabs.onUpdated.addListener(function(tabId, info) {
                   }, function(tabs) {
                     var tab1=tabs[0];
                     tabIdtest=tab1.id;
-                    if((tab.id!=tabIdtest)&&(tab.id!=tabId2)&&(tab.id!=tabId3)&&(tab.id!=tabId4)&&(tab.id!=tabId5)&&(tab.id!=tabId6)&&(tab.id!=tabId7)&&(tab.id!=tabId8)&&(tab.id!=tabId9)){
+                    if((tab.id!=tabIdtest)&&(tab.id!=tabId2)&&(tab.id!=tabId3)&&(tab.id!=tabId4)&&(tab.id!=tabId5)&&(tab.id!=tabId6)&&(tab.id!=tabId7)&&(tab.id!=tabId8)&&(tab.id!=tabId9)&&(tab.id!=tabId10)){
                       if((tab1.url).includes("alexa")){
                         var alexa_url="https://archive.org/services/context/alexa?url="+url;
                         chrome.tabs.update(parseInt(tabIdtest), {url:alexa_url});
@@ -893,6 +931,8 @@ chrome.tabs.onUpdated.addListener(function(tabId, info) {
                       }else if((tab1.url).includes("hoaxy")){
                         var hoaxy_url="http://hoaxy.iuni.iu.edu/#query="+open_url+"&sort=mixed&type=Twitter";
                         chrome.tabs.update(parseInt(tabIdtest), {url:hoaxy_url});
+                      }else if((tab1.url).includes("doi")){
+                        chrome.tabs.update(parseInt(tabIdtest), {url:chrome.runtime.getURL("doi.html")+"?url="+tab.url});
                       }
                       var whois_url="https://archive.org/services/context/whois?url=" + url;
                       chrome.tabs.update(parseInt(tabId2), {url:whois_url});
@@ -905,6 +945,7 @@ chrome.tabs.onUpdated.addListener(function(tabId, info) {
                       chrome.tabs.update(parseInt(tabId7), {url:chrome.runtime.getURL("tagcloud.html")+"?url="+tagcloudurl});
                       var hoaxy_url="http://hoaxy.iuni.iu.edu/#query="+open_url+"&sort=mixed&type=Twitter";
                       chrome.tabs.update(parseInt(tabId9), {url:hoaxy_url});
+                      chrome.tabs.update(parseInt(tabIdtest), {url:chrome.runtime.getURL("doi.html")+"?url="+tab.url});
                     }
                   }); 
                 }
@@ -918,10 +959,10 @@ chrome.tabs.onUpdated.addListener(function(tabId, info) {
               }else{
                 if((windowId1!=0)||(windowId2!=0)||(windowId3!=0)||(windowId4!=0)||(windowId5!=0)||(windowId6!=0)||(windowId7!=0)){
                   chrome.tabs.query({
-                    windowId: windowId1
+                    windowId: windowId10
                   }, function(tabs) {
                     var tab1=tabs[0];
-                    tabIdAlexa=tab1.id;
+                    tabIddoi=tab1.id;
                   });  
                   chrome.tabs.query({
                     windowId: windowId2
@@ -971,9 +1012,15 @@ chrome.tabs.onUpdated.addListener(function(tabId, info) {
                     var tab1=tabs[0];
                     tabIdhoaxy=tab1.id;
                   });
-                  if((tab.id!=tabIdAlexa)&&(tab.id!=tabIdWhois)&&(tab.id!=tabIdtwit)&&(tab.id!=tabIdoverview)&&(tab.id!=tabIdannotation)&&(tab.id!=tabIdsimilarweb)&&(tab.id!=tabIdtagcloud)&&(tab.id!=tabIdannotationurl)&&(tab.id!=tabIdhoaxy)){
+                  chrome.tabs.query({
+                    windowId: windowId1
+                  }, function(tabs) {
+                    var tab1=tabs[0];
+                    tabIdalexa=tab1.id;
+                  });
+                  if((tab.id!=tabIdAlexa)&&(tab.id!=tabIdWhois)&&(tab.id!=tabIdtwit)&&(tab.id!=tabIdoverview)&&(tab.id!=tabIdannotation)&&(tab.id!=tabIdsimilarweb)&&(tab.id!=tabIdtagcloud)&&(tab.id!=tabIdannotationurl)&&(tab.id!=tabIdhoaxy)&&(tab.id!=tabIddoi)){
                     chrome.tabs.query({
-                      windowId: windowId1
+                      windowId: windowId10
                     }, function(tabs) {
                       var tab1=tabs[0];
                       var alexa_url="https://archive.org/services/context/alexa?url="+url;
@@ -1029,6 +1076,12 @@ chrome.tabs.onUpdated.addListener(function(tabId, info) {
                       var tab1=tabs[0];
                       var hoaxy_url="http://hoaxy.iuni.iu.edu/#query="+open_url+"&sort=mixed&type=Twitter";
                       chrome.tabs.update(tab1.id, {url:hoaxy_url});
+                    });
+                    chrome.tabs.query({
+                      windowId: windowId1
+                    }, function(tabs) {
+                      var tab1=tabs[0];
+                      chrome.tabs.update(tab1.id, {url:chrome.runtime.getURL("doi.html")+"?url="+tab.url});
                     });
                   }
                 }   
@@ -1117,8 +1170,8 @@ function openThatContext(temp,url,methodOfShowing){
   var hoaxy_url="http://hoaxy.iuni.iu.edu/#query="+url+"&sort=mixed&type=Twitter";
   if(methodOfShowing=='tab'){
     if(windowIdtest==0){
-      if(temp=='alexa'){
-        chrome.windows.create({url:alexa_url, width:800, height:800, top:0, left:0, focused:true},function (win) {
+      if(temp=='doi'){
+        chrome.windows.create({url:chrome.runtime.getURL("doi.html")+"?url="+url, width:800, height:800, top:0, left:0, focused:true},function (win) {
           windowIdtest = win.id;
           //to add onremoved event listener
         });
@@ -1194,6 +1247,15 @@ function openThatContext(temp,url,methodOfShowing){
             }
           });
         });
+      }else if(temp=='alexa'){
+        chrome.windows.create({url:alexa_url, width:800, height:800, top:0, left:0, focused:true},function (win) {
+          windowIdtest = win.id;
+          chrome.windows.onRemoved.addListener(function (win1) {
+            if(win1==windowIdtest){
+              windowIdtest=0;
+            }
+          });
+        });
       }
     }else{
       chrome.tabs.query({
@@ -1201,10 +1263,10 @@ function openThatContext(temp,url,methodOfShowing){
       }, function(tabs) {
         if(temp=='alexa'){
           chrome.tabs.create({'url': alexa_url,'active':false},function(tab){
-            tabId1=tab.id;
+            tabId10=tab.id;
             chrome.tabs.onRemoved.addListener(function (tabtest) {
-              if(tabtest==tabId1){
-                tabId1=0;
+              if(tabtest==tabId10){
+                tabId10=0;
               }
             });
           });
@@ -1280,6 +1342,15 @@ function openThatContext(temp,url,methodOfShowing){
               }
             });
           });
+        }else if(temp=='doi'){
+          chrome.tabs.create({url:chrome.runtime.getURL("doi.html")+"?url="+url,'active':false},function(tab){
+            tabId1=tab.id;
+            chrome.tabs.onRemoved.addListener(function (tabtest) {
+              if(tabtest==tabId1){
+                tabId1=0;
+              }
+            });
+          });
         }
       });
     }
@@ -1287,10 +1358,10 @@ function openThatContext(temp,url,methodOfShowing){
     //If context is to be shown in window
     if(temp=='alexa'){
       chrome.windows.create({url:alexa_url, width:500, height:500, top:0, left:0, focused:false},function (win) {
-        windowId1 = win.id;
+        windowId10 = win.id;
         chrome.windows.onRemoved.addListener(function (win1) {
-          if(win1==windowId1){
-            windowId1=0;
+          if(win1==windowId10){
+            windowId10=0;
           }
         });
       });
@@ -1363,6 +1434,15 @@ function openThatContext(temp,url,methodOfShowing){
         chrome.windows.onRemoved.addListener(function (win1) {
           if(win1==windowId9){
             windowId9=0;
+          }
+        });
+      });
+    }else if (temp=='doi'){
+      chrome.windows.create({url:chrome.runtime.getURL("doi.html")+"?url="+url,width:600, height:500, top:0, left:1200, focused:false},function (win) {
+        windowId1 = win.id;
+        chrome.windows.onRemoved.addListener(function (win1) {
+          if(win1==windowId1){
+            windowId1=0;
           }
         });
       });

--- a/scripts/doi.js
+++ b/scripts/doi.js
@@ -1,0 +1,68 @@
+function getUrlByParameter(name){
+    console.log(window.location.href)
+    var url=window.location.href;
+    var indexOfEnd=url.length;
+    var index=url.indexOf(name);
+    var length=name.length;
+    return url.slice(index+length+1,indexOfEnd);
+}
+function createList(mainContainer,listEl){
+    var mainRow=document.createElement('div');
+    mainRow.className='row row_main';
+    mainContainer.appendChild(mainRow);
+    var half = document.createElement('div');
+    half.className='col-xs-6 half';
+    mainRow.appendChild(half);
+    var subRow=document.createElement('div');
+    subRow.className = 'row box';
+    half.appendChild(subRow);
+    var title = document.createElement('div');
+    var link = document.createElement('div');
+    title.className = 'col-xs-9';
+    link.className = 'col-xs-3';
+    subRow.appendChild(title);
+    subRow.appendChild(link);
+    title.innerHTML = listEl.title;
+    if(listEl.url == null){
+        link.innerHTML = "Not available";
+        link.style.color = "red";
+    }else{
+        var btn = document.createElement('button');
+        btn.setAttribute('type','button');
+        btn.className = "btn btn-lg btn-success";
+        link.appendChild(btn);
+        btn.innerHTML = "Read";
+        btn.addEventListener('click',function(event){
+            window.open(listEl.url);
+        });
+    }
+}
+function createPage(){
+    var url=getUrlByParameter('url');
+    console.log(url);
+    var xhr=new XMLHttpRequest();
+    xhr.open('GET','https://archive.org/services/context/papers?url='+url,true);
+    xhr.onload=function(){
+        var responseArray = JSON.parse(xhr.responseText);
+        console.log(responseArray);
+        var result = [];
+        for(var i=0;i<responseArray.length;i++){
+            if(responseArray[i].count_files==0 && responseArray[i].paper && responseArray[i].paper.title){
+                result.push({url:null,title:responseArray[i].paper.title});
+            }else if(responseArray[i].count_files>0 && responseArray[i].files.length>0 && responseArray[i].files[0].links.length>0 && responseArray[i].files[0].links[0].url && responseArray[i].paper && responseArray[i].paper.title){
+                result.push({url:responseArray[i].files[0].links[0].url,title:responseArray[i].paper.title});
+            }
+        }
+        var mainContainer = document.getElementById('container-whole');
+        mainContainer.innerHTML = "";
+        console.log(result);
+        for(var i=0;i<result.length;i++){
+            createList(mainContainer,result[i]);
+        }
+        if(result.length==0){
+            document.getElementById('doi-heading').innerHTML="No papers found";
+        }
+    };
+    xhr.send();
+}
+window.onload = createPage;

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -15,8 +15,9 @@ function restore_options() {
     similarweb:false,
     tagcloud:false,
     hoaxy:false,
-    showall:false,
-    news:false
+    doi:false,
+    news:false,
+    showall:false
   }, function(items) {
     document.getElementById('auto-archive').checked = items.auto_archive;
     document.getElementById('books').checked = items.books;
@@ -33,6 +34,7 @@ function restore_options() {
     document.getElementById('hoaxy').checked = items.hoaxy;
     document.getElementById('showall').checked = items.showall;
     document.getElementById('news').checked = items.news;
+    document.getElementById('doi').checked = items.doi;
   });
 }
 function save_options() {
@@ -51,6 +53,7 @@ function save_options() {
   var hoaxy = document.getElementById('hoaxy').checked;
   var showall= document.getElementById('showall').checked;
   var news = document.getElementById('news').checked;
+  var doi = document.getElementById('doi').checked;
   chrome.storage.sync.set({
     show_context:show_context,
     auto_archive: auto_archive,
@@ -66,7 +69,8 @@ function save_options() {
     tagcloud:tagcloud,
     hoaxy:hoaxy,
     showall:showall,
-    news:news
+    news:news,
+    doi:doi
   }, function() {
     var status = document.getElementById('status');
     status.textContent = 'Options saved.';

--- a/scripts/singleWindow.js
+++ b/scripts/singleWindow.js
@@ -383,14 +383,69 @@ function percentEncode(str) {
       return '%' + character.charCodeAt(0).toString(16);
     });
 };
-
-window.onloadFuncs = [get_alexa,get_whois,get_details,first_archive_details,recent_archive_details,get_thumbnail,get_tweets,get_annotaions_url,get_tags];
+function createList(mainContainer,listEl){
+    var mainRow=document.createElement('div');
+    mainRow.className='row row_main';
+    mainContainer.appendChild(mainRow);
+    var half = document.createElement('div');
+    half.className='col-xs-6 half';
+    mainRow.appendChild(half);
+    var subRow=document.createElement('div');
+    subRow.className = 'row box';
+    half.appendChild(subRow);
+    var title = document.createElement('div');
+    var link = document.createElement('div');
+    title.className = 'col-xs-9';
+    link.className = 'col-xs-3';
+    subRow.appendChild(title);
+    subRow.appendChild(link);
+    title.innerHTML = listEl.title;
+    if(listEl.url == null){
+        link.innerHTML = "Not available";
+        link.style.color = "red";
+    }else{
+        var btn = document.createElement('button');
+        btn.setAttribute('type','button');
+        btn.className = "btn btn-lg btn-success";
+        link.appendChild(btn);
+        btn.innerHTML = "Read";
+        btn.addEventListener('click',function(event){
+            window.open(listEl.url);
+        });
+    }
+}
+function get_doi(){
+    var url=getUrlByParameter('url');
+    console.log(url);
+    var xhr=new XMLHttpRequest();
+    xhr.open('GET','https://archive.org/services/context/papers?url='+url,true);
+    xhr.onload=function(){
+        var responseArray = JSON.parse(xhr.responseText);
+        console.log(responseArray);
+        var result = [];
+        for(var i=0;i<responseArray.length;i++){
+            if(responseArray[i].count_files==0 && responseArray[i].paper && responseArray[i].paper.title){
+                result.push({url:null,title:responseArray[i].paper.title});
+            }else if(responseArray[i].count_files>0 && responseArray[i].files.length>0 && responseArray[i].files[0].links.length>0 && responseArray[i].files[0].links[0].url && responseArray[i].paper && responseArray[i].paper.title){
+                result.push({url:responseArray[i].files[0].links[0].url,title:responseArray[i].paper.title});
+            }
+        }
+        var mainContainer = document.getElementById('doi');
+        mainContainer.innerHTML = "";
+        console.log(result);
+        for(var i=0;i<result.length;i++){
+            document.getElementById('doi-heading').style.display="block";
+            createList(mainContainer,result[i]);
+        }
+    };
+    xhr.send();
+}
+window.onloadFuncs = [get_alexa,get_whois,get_details,first_archive_details,recent_archive_details,get_thumbnail,get_tweets,get_annotaions_url,get_tags,get_doi];
 window.onload = function(){
  for(var i in this.onloadFuncs){
   this.onloadFuncs[i]();
  }
 }
-
 var mynewTags=new Array();
 function get_tags(){
     var url=getUrlByParameter('url');

--- a/settings.html
+++ b/settings.html
@@ -124,6 +124,11 @@
                             <span class="enable"><b>Social Graph (Hoaxy)</b></span>
                         </label>
                         <br>
+                        <label for="doi" style="font-size: 14px;">
+                            <input type="checkbox" name="context" id="doi" class="only">
+                            <span class="enable"><b>Scientific Publications</b></span>
+                        </label>
+                        <br>
                         <label for="showall" style="font-size: 14px;">
                             <input type="checkbox" id="showall">
                             <span class="enable"><b>Show All Context Screens</b></span> 

--- a/singleWindow.html
+++ b/singleWindow.html
@@ -27,6 +27,14 @@
                 </td>
             </tr>
         </table>
+        <div class="container" style="width: 100%;text-align: center;">
+            <div id="doi-heading">
+                <h2><strong>Current Wikipedia Page Scientific Publications"</strong></h2>
+            </div>
+            <div id="doi">
+                
+            </div>            
+        </div>
         <div>
             <h2 style="text-align: center;"><strong>Alexa, Whois overview of Current URL</strong><br></h2>
         </div>


### PR DESCRIPTION
All DOI's from a Wikipedia page are displayed as a context with links to read at web.archive.org
DOI's are read from the page, queried at https://scholar.archivelab.org/id/doi/ and sent to background.js as an array. Then the context screen requests this array from background.js and displays the DOI's and links on doi.html or singleWindow.html