### PR TITLE
Replace metadata context URL

### DIFF
--- a/scripts/overview.js
+++ b/scripts/overview.js
@@ -10,7 +10,7 @@ function getUrlByParameter(name){
 function get_details(){
     var url=getUrlByParameter('url');
     var xhr=new XMLHttpRequest();
-    var new_url="http://web.archive.org/__wb/search/metadata?q="+url;
+    var new_url="https://archive.org/services/context/metadata?url="+url;
     xhr.open("GET",new_url,true);
     xhr.onload=function(){
         var type=JSON.parse(xhr.response).type;

--- a/scripts/singleWindow.js
+++ b/scripts/singleWindow.js
@@ -88,7 +88,7 @@ function get_whois(url){
 function get_details(){
     var url=getUrlByParameter('url');
     var xhr=new XMLHttpRequest();
-    var new_url="http://web.archive.org/__wb/search/metadata?q="+url;
+    var new_url="https://archive.org/services/context/metadata?url="+url;
     xhr.open("GET",new_url,true);
     xhr.onload=function(){
         var type=JSON.parse(xhr.response).type;


### PR DESCRIPTION
Use `https://archive.org/services/context/metadata?url=example.com`
Instead of `http://web.archive.org/__wb/search/metadata?q=example.com`