### PR TITLE
Fix spinning loader in books context

### DIFF
--- a/booklist.html
+++ b/booklist.html
@@ -23,8 +23,8 @@
       </td>
     </tr>
   </table> -->
-  <div>
-    <h2 style="text-align: center;"><strong>Cited Books</strong></h2>
+  <div class="text-center">
+    <h2><strong id="books-heading">Cited Books</strong></h2>
   </div>
   <BR>
   <div class="loader"></div>
@@ -32,6 +32,6 @@
   </div>
 </body>
 </html>
-<script src="scripts/booklist.js"></script>
 <script src="scripts/build.js"></script>
+<script src="scripts/booklist.js"></script>
 <script src="scripts/booklist_loader.js"></script>


### PR DESCRIPTION
Fix a bug with spinning loader that keeps working even though we haven't
found any books.

Replace `XMLHttpRequest` code with `$.getJSON` to simplify code.

Fix eslint errors.