### PR TITLE
Optimise annotation context code

### DIFF
--- a/annotation.html
+++ b/annotation.html
@@ -6,7 +6,6 @@
         <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
         <link rel="stylesheet" type="text/css" href="css/common.css">
         <link rel="stylesheet" type="text/css" href="css/annotation.css">
-        <link rel="stylesheet" type="text/css" href="css/font-awesome.min.css">
         <title>
             Annotation of an Domain if any
         </title>
@@ -25,27 +24,26 @@
             </tr>
         </table> -->
         <div>
-            <h2><strong>Annotations of Current Domain</strong><br><span class="annot_title"> From <a style="cursor: pointer;" href="http://hypothes.is/">Hypothes.is</a></span></h2>
+            <h2><strong>Annotations of Current Domain</strong><br>
+                <span class="annot_title"> From <a style="cursor: pointer;" href="http://hypothes.is/">Hypothes.is</a></span></h2>
         </div>
         <div class="container" id="container-whole"></div>
-        <div class="row row_main" id="row_contain">
-            <div class="col-sm-6" id="half">
+        <div class="row" id="row_contain">
+            <div class="col-sm-6 col-sm-offset-3">
                 <div class="box">
-                    <div class="top-div" id="top-div-contain">
-                        <strong>
-                            <span id="userinfo"></span>
-                        </strong>
-                        <span id="date"></span>
+                    <div>
+                        <strong class="userinfo"></strong>
+                        <span class="date"></span>
                     </div>
                     <div class="source" id="source-">
-                        <span class="glyphicon glyphicon-globe" id="public"></span>
-                        <span class="public_on">Public on</span>
-                        <span class="title" id="title-contain"></span>
+                        <span class="glyphicon glyphicon-globe"></span>
+                        <span class="text-muted">Public on</span>
+                        <span class="title text-danger"></span>
                         <span id="source-contain"></span>
                     </div>
-                    <div class="target-selector-exact" id="target-selector-exact-contain"></div>
+                    <div class="target-selector-exact"></div>
                     <div class="text" id="text-contain"></div>
-                    <div id="links"></div>
+                    <div class="links"></div>
                 </div>
             </div>
         </div>

--- a/annotation.html
+++ b/annotation.html
@@ -51,4 +51,7 @@
         </div>
     </body>
 </html>
+<script src="scripts/build.js"></script>
+<script src="scripts/utils.js"></script>
 <script src="scripts/annotation.js"></script>
+<script src="scripts/annotation_loader.js"></script>

--- a/css/annotation.css
+++ b/css/annotation.css
@@ -1,24 +1,9 @@
-body{
-    max-height: 100%;
-}
-
 .annot_title{
     font-size: 50%;
     font-family:sans-serif;
 }
 h2{
     text-align: center;
-}
-.container{
-    background: white;
-    padding-left: 15px;
-    padding-right: 15px;
-    margin-left: auto;
-    margin-right: auto;
-}
-p{
-    font-family:Gill Sans Light;
-    font-size: 20px;
 }
 .box{
     align-items: stretch;
@@ -34,9 +19,15 @@ p{
     overflow: hidden;
     padding: 5px 5px 5px 5px;
 }
-.target-selector-exact{
+.target-selector-exact {
+    border-left: 3px solid #d3d3d3;
+    color: #7A7A7A;
     font-family:'Courier New', Courier, monospace;
+    padding: 5px;
     word-wrap: break-word;
+}
+.target-selector-exact:hover{
+    border-left: 3px solid #58CEF4;
 }
 #link-incontext{
     margin-left:40px; 
@@ -44,7 +35,7 @@ p{
 #link-html{
     margin-left: 70px;
 }
-#date{
+.date{
     position: absolute;
     right: 20px;
 }
@@ -54,15 +45,7 @@ p{
 #text-contain{
     padding: 5px;
 }
-#target-selector-exact-contain{
-    border-left: 3px solid #d3d3d3;
-    color: #7A7A7A;
-    padding: 5px;
-}
-#target-selector-exact-contain:hover{
-    border-left: 3px solid #58CEF4;
-}
-#links{
+.links{
     padding: 10px;
 }
 .extra_margin{
@@ -71,23 +54,8 @@ p{
 .lower_margin{
     margin-bottom: 5px;
 }
-.row_main{
-    align-items: stretch;
-    display: flex;
-    justify-content: center;
-}
-#half{
-    width: 600px;
-}
 #source-contain{
     word-wrap: break-word;
-}
-#title-contain{
-    color: red;
-}
-.public_on{
-    color: #818181;
-    font-weight: 150%;
 }
 @media screen and (max-width: 500px) {
     #link-incontext {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wayback-machine-chrome",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A browser extension that interfaces with the internet archive",
   "main": "index.js",
   "directories": {

--- a/scripts/annotation.js
+++ b/scripts/annotation.js
@@ -1,82 +1,55 @@
-//Used to extact the current URL
-function getUrlByParameter(name){
-    var url=window.location.href;
-    var indexOfEnd=url.length;
-    var index=url.indexOf(name);
-    var length=name.length;
-    return url.slice(index+length+1,indexOfEnd);
-}
-
-function get_annotations(){
-    var url=getUrlByParameter('url');
-    console.log(url);
-    var xhr= new XMLHttpRequest();
-    var test_url=url.replace(/^https?:\/\//,'');
-    if(test_url.includes('iskme.org')){
-        test_url=test_url.replace(/^www\./,'');
-    }
-    console.log(test_url);
-    test_url=test_url.replace('/','.')
-    var url=test_url.split(".");
-    var main_url="";
-    for(var i=0;i<url.length-1;i++){
-        main_url+="&uri.parts="+url[i];
-    }
-    var new_url="https://hypothes.is/api/search?"+main_url;
-    xhr.open("GET",new_url,true);
-    xhr.onload=function(){
-        var data=JSON.parse(xhr.response);
-        var length=data.rows.length;
-        console.log(data);
-        if(length>0){
-            for(var i=0;i<length;i++){
-                var rowData=data.rows[i];
-                var date=rowData.created.substring(0,10);
-                var source=rowData.target[0].source;
-                var exactData=rowData.text;
-                var user=rowData.user.substring(5,rowData.user.indexOf('@'));
-                var row=document.getElementById('row_contain');
-                var item=row.cloneNode(true);
-                var topDivDate=item.querySelectorAll('[id="date"]')[0].appendChild(document.createTextNode("Dated on :"+date));
-                var topDivUserInfo=item.querySelectorAll('[id="userinfo"]')[0].appendChild(document.createTextNode(user));
-                var targetSelectorExact=item.querySelectorAll('[id="source-contain"]')[0].appendChild(document.createTextNode("("+source+")"));
-                var text=item.querySelectorAll('[id="text-contain"]')[0].appendChild(document.createTextNode(exactData));
-                var title=item.querySelectorAll('[id="title-contain"]')[0].appendChild(document.createTextNode(rowData.document.title[0]));
-                var createA = document.createElement('a');
-                var createAText = document.createTextNode("Click to see the in-context");
-                createA.setAttribute('href', rowData.links.incontext);
-                createA.setAttribute('id',"link-incontext");
-                createA.appendChild(createAText);
-                var date=item.querySelectorAll('[id="links"]')[0].appendChild(createA);
-                var createB = document.createElement('a');
-                var createBText = document.createTextNode("Click to see the HTML");
-                createB.setAttribute('href', rowData.links.html);
-                createB.setAttribute('id',"link-html");
-                createB.appendChild(createBText);
-                var linked1=item.querySelectorAll('[id="links"]')[0].appendChild(createA);
-                var linked2=item.querySelectorAll('[id="links"]')[0].appendChild(createB);
-                if(rowData.target[0].hasOwnProperty('selector')){
-                    var lengthOfSelctor=rowData.target[0].selector.length;
-                    var selector=rowData.target[0].selector[lengthOfSelctor-1].exact;
-                    var selectorDiv=item.querySelectorAll('[id="target-selector-exact-contain"]')[0].appendChild(document.createTextNode(selector));
-                }
-                else{
-                    item.querySelectorAll('[id="target-selector-exact-contain"]')[0].style.display="none";
-                }
-                item.id = "row-"+i;
-                document.getElementById("container-whole").appendChild(item);
-            }
-            document.getElementById("row_contain").style.display="none";
-        }else{
-            document.getElementById("row_contain").innerHTML="There are no Annotations for the current URL";
+function get_annotations() {
+  var url = getUrlByParameter('url');
+  // TODO URL processing needs to be a separate function and also needs cleanup.
+  var test_url = url.replace(/^https?:\/\//,'');
+  if(test_url.includes('iskme.org')){
+    test_url=test_url.replace(/^www\./,'');
+  }
+  console.log(test_url);
+  test_url = test_url.replace('/','.')
+  var url = test_url.split(".");
+  var main_url = "";
+  for(var i=0;i<url.length-1;i++){
+    main_url += '&uri.parts=' + url[i];
+  }
+  var new_url = 'https://hypothes.is/api/search?' + main_url;
+  // TODO
+  console.log(new_url);
+  $.getJSON(new_url, function(data) {
+    const length = data.rows.length;
+    if (length > 0) {
+      for(let i=0; i<length; i++) {
+        const rowData = data.rows[i];
+        const date = rowData.created.substring(0,10);
+        const source = rowData.target[0].source;
+        const exactData = rowData.text;
+        const user = rowData.user.substring(5,rowData.user.indexOf('@'));
+        const title = rowData.document.title[0];
+        let row = $('#row_contain');
+        let item = row.clone();
+        item.attr('id', 'row-' + i);
+        item.find('#date').html('Dated on ' + date);
+        item.find('#userinfo').html(user);
+        item.find('#source-contain').html('(' + source + ')');
+        item.find('#text-contain').html(exactData);
+        item.find('#title-contain').html(title);
+        item.find('#links').append(
+          $('<a>').attr({'href': rowData.links.incontext, 'id': 'link-incontext'})
+                  .html('Click to see the in-context'),
+          $('<a>').attr({'href': rowData.links.html, 'id': 'link-html'})
+                  .html('Click to see the HTML')
+        )
+        if(rowData.target[0].hasOwnProperty('selector')){
+          var selector_length = rowData.target[0].selector.length;
+          var exact = rowData.target[0].selector[selector_length-1].exact;
+          item.find('#target-selector-exact-contain').append(exact);
+        } else {
+          item.find('#target-selector-exact-contain').hide();
         }
+        $('#container-whole').append(item);
+      }
+    } else {
+      $('#row_contain').html("There are no Annotations for the current URL");
     }
-    xhr.send(null);
-}
-
-window.onloadFuncs = [get_annotations];
-window.onload = function(){
- for(var i in this.onloadFuncs){
-  this.onloadFuncs[i]();
- }
+  });
 }

--- a/scripts/annotation.js
+++ b/scripts/annotation.js
@@ -28,12 +28,12 @@ function get_annotations() {
         let row = $('#row_contain');
         let item = row.clone();
         item.attr('id', 'row-' + i);
-        item.find('#date').html('Dated on ' + date);
-        item.find('#userinfo').html(user);
+        item.find('.date').html('Dated on ' + date);
+        item.find('.userinfo').html(user);
         item.find('#source-contain').html('(' + source + ')');
         item.find('#text-contain').html(exactData);
-        item.find('#title-contain').html(title);
-        item.find('#links').append(
+        item.find('.title').html(title);
+        item.find('.links').append(
           $('<a>').attr({'href': rowData.links.incontext, 'id': 'link-incontext'})
                   .html('Click to see the in-context'),
           $('<a>').attr({'href': rowData.links.html, 'id': 'link-html'})
@@ -42,12 +42,13 @@ function get_annotations() {
         if(rowData.target[0].hasOwnProperty('selector')){
           var selector_length = rowData.target[0].selector.length;
           var exact = rowData.target[0].selector[selector_length-1].exact;
-          item.find('#target-selector-exact-contain').append(exact);
+          item.find('.target-selector-exact').html(exact);
         } else {
-          item.find('#target-selector-exact-contain').hide();
+          item.find('.target-selector-exact').hide();
         }
         $('#container-whole').append(item);
       }
+      $('#row_contain').hide();
     } else {
       $('#row_contain').html("There are no Annotations for the current URL");
     }

--- a/scripts/annotation_loader.js
+++ b/scripts/annotation_loader.js
@@ -1,0 +1,1 @@
+window.onload = get_annotations;


### PR DESCRIPTION
Rewrite `annotation.js` using jQuery.

Cleanup annotation.html markup and CSS rules.

The UI remains exactly the same as before.