### PR TITLE
Fixed bug regarding not seeing user name in annotation_URL context

### DIFF
--- a/annotation.html
+++ b/annotation.html
@@ -32,7 +32,7 @@
             <div class="col-sm-6 col-sm-offset-3">
                 <div class="box">
                     <div>
-                        <strong class="userinfo"></strong>
+                        <strong id="userinfo"></strong>
                         <span class="date"></span>
                     </div>
                     <div class="source" id="source-">

--- a/scripts/annotation.js
+++ b/scripts/annotation.js
@@ -37,7 +37,7 @@ function get_annotations(type) {
         let item = row.clone();
         item.attr('id', 'row-' + i);
         item.find('.date').html('Dated on ' + date);
-        item.find('.userinfo').html(user);
+        item.find('#userinfo').html(user);
         item.find('#source-contain').html('(' + source + ')');
         item.find('#text-contain').html(exactData);
         item.find('.title').html(title);


### PR DESCRIPTION
I have fixed the bug, when I try for finding Annotations of Current URL for an URL, I am not seeing the user name which I could see in Annotations of Current Domain.