### PR TITLE
Fix invalid not found handler URL parameters format

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -86,7 +86,7 @@ chrome.webRequest.onCompleted.addListener(function(details) {
               file: "scripts/client.js"
             },function() {
               if(chrome.runtime.lastError && chrome.runtime.lastError.message.startsWith('Cannot access contents of url "chrome-error://chromewebdata/')){
-                chrome.tabs.update(details.tabId, {url: chrome.extension.getURL('dnserror.html')+"?wayback_url="+wayback_url+"?page_url="+url+"?status_code="+details.statusCode+"?"});
+                chrome.tabs.update(details.tabId, {url: chrome.extension.getURL('dnserror.html')+"?wayback_url="+wayback_url+"&page_url="+url+"&status_code="+details.statusCode});
               }else{
                 chrome.tabs.sendMessage(details.tabId, {
                   type: "SHOW_BANNER",
@@ -694,7 +694,7 @@ chrome.webRequest.onCompleted.addListener(function(details) {
           if(details.error == 'net::ERR_NAME_NOT_RESOLVED' || details.error == 'net::ERR_NAME_RESOLUTION_FAILED'
           || details.error == 'net::ERR_CONNECTION_TIMED_OUT'  || details.error == 'net::ERR_NAME_NOT_RESOLVED' ){
             wmAvailabilityCheck(details.url, function(wayback_url, url) {
-              chrome.tabs.update(details.tabId, {url: chrome.extension.getURL('dnserror.html')+"?wayback_url="+wayback_url+"?page_url="+url+"?status_code="+details.statusCode+"?"});
+              chrome.tabs.update(details.tabId, {url: chrome.extension.getURL('dnserror.html')+"?wayback_url="+wayback_url+"&page_url="+url+"&status_code="+details.statusCode});
             }, function() {
 
             });

--- a/scripts/dnserror.js
+++ b/scripts/dnserror.js
@@ -1,18 +1,8 @@
-/*----New way of getParameterByName-----*/
 function getParameterByName(name){
-    var url=window.location.href;
-    var index=url.indexOf(name);
-    var length=name.length;
-    var indexOfEnd;
-    for(var i=index;i<url.length;i++){
-        if(url[i]=='?'){
-            indexOfEnd=i;
-            break;
-        }
-    }
-    return url.slice(index+length+1,indexOfEnd);
+  const url = new URL(window.location.href);
+  return url.searchParams.get(name);
 }
 
 document.getElementById('no-more-404s-dnserror-link').href = getParameterByName('wayback_url');
-document.getElementById('status-code-show').innerHTML=getParameterByName('status_code');
-document.getElementById('url-show').innerHTML=getParameterByName('page_url');
+document.getElementById('status-code-show').innerHTML = getParameterByName('status_code');
+document.getElementById('url-show').innerHTML = getParameterByName('page_url');


### PR DESCRIPTION
When a page is not found (e.g. 404), we are redirected to a "Not Found"
page.
That page had invalid URL parameter separators (`?` everywhere instead
of `&` !!) like this:

```
chrome-extension://leihjocjpbflfcepbmiappahbckagncn/dnserror.html?wayback_url=https://web.archive.org/web/20180821103430/http://dataopen.eu/?page_url=http://dataopen.eu/?status_code=404?
```

We fix this bug and improve the code to get the parameter values in
`scripts/dnserror.js`.