### PR TITLE
Fixed bug regarding not seeing user name in annotation_URL context

### DIFF
--- a/annotationURL.html
+++ b/annotationURL.html
@@ -32,7 +32,7 @@
             <div class="col-sm-6 col-sm-offset-3">
                 <div class="box">
                     <div>
-                        <strong id="userinfo"></strong>
+                        <strong class="userinfo"></strong>
                         <span class="date"></span>
                     </div>
                     <div class="source" id="source-">


### PR DESCRIPTION
I have fixed the bug, when I try for finding Annotations of Current URL for an URL, I am not seeing the user name which I could see in Annotations of Current Domain.
I have replaced the ID by Class for which it was not working.
Thank you!!