### PR TITLE
Refactors wikipedia papers CS

### DIFF
--- a/doi.html
+++ b/doi.html
@@ -7,6 +7,7 @@
         <link rel="stylesheet" type="text/css" href="css/common.css">
         <link rel="stylesheet" type="text/css" href="css/font-awesome.min.css">
         <script src="scripts/build.js"></script>
+        <script src="scripts/utils.js"></script>
         <script src="scripts/doi.js"></script>
         <script src="scripts/doi_loader.js"></script>
         <title>

--- a/scripts/doi.js
+++ b/scripts/doi.js
@@ -1,9 +1,5 @@
+function getMetadata(entry){
 
-function getUrlByParameter (name) {
-  const url = new URL(window.location.href);
-  return url.searchParams.get(name);
-}
-function createList (entry, mainContainer) {
   let title = entry.title;
   let author = '';
   if (entry.authors) {
@@ -22,17 +18,27 @@ function createList (entry, mainContainer) {
   if (entry.url) {
     url = entry.url;
   }
+  return {
+    "title": title,
+    "author": author,
+    "journal": journal,
+    "url": url,
+    "source": entry.source
+  };
+}
+
+function makeEntry (data) {
   let paper = $('<div>').append(
     $('<p class="text_elements">').append(
       $('<p>').append(
-        $('<strong>').text(title)
+        $('<strong>').text(data.title)
       ),
-      $('<p>').append(author)
+      $('<p>').append(data.author)
       // Journal was also commented out in the previous version.
       // $('<p>').append(journal)
     )
   );
-  if (url !== '#') {
+  if (data.url !== '#') {
     paper.append(
       $('<a>').attr({'href':'#', 'class': 'btn btn-success'}).text('Read Paper')
         .click(function () {
@@ -41,44 +47,50 @@ function createList (entry, mainContainer) {
               event1.show_context = 'tab';
             }
             if (event1.show_context === 'tab') {
-              chrome.tabs.create({url: url});
+              chrome.tabs.create({url: data.url});
             } else {
               chrome.system.display.getInfo(function (displayInfo) {
                 const height = displayInfo[0].bounds.height;
                 const width = displayInfo[0].bounds.width;
-                chrome.windows.create({url: url, width: width / 2, height: height,
+                chrome.windows.create({url: data.url, width: width / 2, height: height,
                                        top: 0, left: 0, focused: true});
               });
             }
           });
         }),
-      $('<div>').addClass('small text-muted').text('source: ' + entry.source)
+      $('<div>').addClass('small text-muted').text('source: ' + data.source)
     );
   } else {
     paper.append($('<p>').text('Paper Unavailable').addClass('not_found'));
   }
-  // add to list
-  $('.loader').hide();
-  let container = $('#container-whole');
-  if (url !== '#' && container.children().length > 0) {
-    container.prepend(paper);
-  } else {
-    container.append(paper);
-  }
+  return paper;
 }
+
 function createPage () {
-  let mainContainer = document.getElementById('container-whole');
+  let container = $('#container-whole');
   const url = getUrlByParameter('url');
-  $.getJSON('https://archive.org/services/context/papers?url='+url, function(data) {
-    for (var i=0; i<data.length; i++){
-      if (data[i]) {
-        createList(data[i]);
+  $.getJSON('https://archive.org/services/context/papers?url='+url, function(response) {
+    $('.loader').hide();
+    for (var i=0; i<response.length; i++){
+      if (response[i]) {
+        let data = getMetadata(response[i]);
+        let paper = makeEntry(data);
+        // add to list
+        if (data.url !== '#') {
+          container.prepend(paper);
+        } else {
+          container.append(paper);
+        }
       }
     }
-    if (mainContainer.children.length === 0) {
-      $('.loader').hide();
+    if (container.children.length === 0) {
       $('#doi-heading').html('No papers found.');
     }
   });
 }
-if (typeof module !== 'undefined') { module.exports = {getUrlByParameter: getUrlByParameter} }
+if (typeof module !== 'undefined') {
+  module.exports = {
+    getMetadata: getMetadata,
+    makeEntry: makeEntry
+  }
+}

--- a/test/doi.spec.js
+++ b/test/doi.spec.js
@@ -1,11 +1,54 @@
 const dom = require("./setup").jsdom;
 const expect = require("chai").expect;
-const getUrlByParameter = require("../scripts/doi").getUrlByParameter;
+const getMetadata = require("../scripts/doi").getMetadata;
 
-describe('doi', () =>{
-  it('should extract wikipedia url', () =>{
-    dom.reconfigure({url: "chrome-extension://hkahpanhaccgppbidkekeijffcdppdan/booklist.html?url=https://en.wikipedia.org/wiki/Easter_Island"});
-    let wikiURL = getUrlByParameter("url");
-    expect(wikiURL).to.be.equal("https://en.wikipedia.org/wiki/Easter_Island");
+describe('doi: getMetadata()', () =>{
+  let response = {
+    "abstracts": [],
+    "container_id": "hcivi5alwffalcl3q2yireetlm",
+    "contribs": [
+      {
+        "extra": {
+          "sequence": "first"
+        },
+        "index": 0,
+        "raw_name": "David R. Gibson",
+        "role": "author"
+      }
+    ],
+    "count_files": 1,
+    "doi": "10.1086/661761",
+    "extra": {
+      "crossref": {
+        "alternative-id": [
+          "10.1086/661761"
+        ],
+        "container-title": [
+          "American Journal of Sociology"
+        ],
+        "is_kept": false,
+        "type": "journal-article"
+      }
+    },
+    "ident": "qlymqxxsx5gttocoz77hq3e5ju",
+    "issue": "2",
+    "pages": "361-419",
+    "publisher": "University of Chicago Press",
+    "refs": [],
+    "release_date": "2011-01-01T00:00:00Z",
+    "release_status": "published",
+    "release_type": "journal-article",
+    "revision": "844a08b1-ab28-4b1b-bcda-350baa55bf08",
+    "source": "archive.org",
+    "state": "active",
+    "title": "Avoiding Catastrophe: The Interactional Production of Possibility                     during the Cuban Missile Crisis",
+    "url": "https://web.archive.org/web/2017/http://www.belfercenter.org/sites/default/files/legacy/files/CMC50/DavidGibsonAvoidingCatastropheTheInteractionalProductionofPossibilityDuringTheCubanMissileCrisisAmericanJournalofSociology.pdf",
+    "volume": "117",
+    "wikidata_qid": "Q56040827",
+    "work_id": "3xykhxcnubhqrcjz3k5f46fkxq"
+  };
+  it('should normalize data from response', ()=> {
+    let result = getMetadata(response);
+    expect(result).to.have.keys(["title", "author", "journal", "url", "source"]);
   });
 });


### PR DESCRIPTION
- Includes utils.js in doi.html and eliminates `getUrlByParameter()`
- Breaks large function into smaller units and adds some tests