### PR TITLE
Suggestion to read amazon.com books doesn't show up

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -738,28 +738,19 @@ chrome.tabs.onUpdated.addListener(function(tabId, info) {
         });
       }
       chrome.storage.sync.get(['books'],function(event){
-        if(event.books==true){
-          chrome.tabs.query({active: true,currentWindow:true},function(tabs){
-            url=tabs[0].url;
-            tabId=tabs[0].id;
+        if (event.books === true) {
+          chrome.tabs.query({active: true, currentWindow:true}, function(tabs){
+            url = tabs[0].url;
+            tabId = tabs[0].id;
             if(url.includes("www.amazon")){
-              var xhr=new XMLHttpRequest();
-              var new_url="https://archive.org/services/context/amazonbooks?url="+url;
-              xhr.open("GET",new_url,true);
+              var xhr = new XMLHttpRequest();
+              xhr.open('GET', 'https://archive.org/services/context/amazonbooks?url=' + url, true);
               xhr.send(null);
-              xhr.onload=function(){
-                var response = JSON.parse(xhr.response);
-                if(response.success==true && response.error==undefined){
-                  var responses=response.responses;
-                  for(var propName in responses) {
-                    if(responses.hasOwnProperty(propName)) {
-                      var propValue = responses[propName];
-                    }
-                  }
-                  var identifier=propValue.identifier;
-                  if(identifier!=undefined||null){
-                    chrome.browserAction.setBadgeText({tabId: tabId, text:"B"});
-                  }
+              xhr.onload = function () {
+                const resp = JSON.parse(xhr.response);
+                if (('metadata' in resp && 'identifier' in resp['metadata']) ||
+                    'ocaid' in resp) {
+                  chrome.browserAction.setBadgeText({tabId: tabId, text: 'B'});
                 }
               }
             }


### PR DESCRIPTION
The method we have to check if we are in an amazon.com book URL in order
to lookup `archive.org/services/context/amazonbooks` did not work
correctly because it checked the previous format of the results and not
the new one.

We fix this bug.