### PR TITLE
Remove duplicate WBM availability check functions

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,5 +152,6 @@
   </body>
 </html>
 <script src="scripts/build.js"></script>
+<script src="scripts/utils.js"></script>
 <script src="scripts/amazon.js"></script>
 <script src="scripts/popup.js"></script>

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,8 @@
       "<all_urls>"
   ],
   "background": {
-    "scripts": ["scripts/background.js"],
+    "scripts": ["scripts/utils.js",
+                "scripts/background.js"],
     "persistent": true
   },
   "content_scripts": [

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -58,55 +58,6 @@ function rewriteUserAgentHeader(e) {
   }
   return {requestHeaders: e.requestHeaders};
 }
-/**
-* Checks Wayback Machine API for url snapshot
-*/
-function wmAvailabilityCheck(url, onsuccess, onfail) {
-  var xhr = new XMLHttpRequest();
-  var requestUrl = "https://archive.org/wayback/available";
-  var requestParams = "url=" + encodeURI(url);
-  xhr.open("POST", requestUrl, true);
-  xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
-  xhr.setRequestHeader("Wayback-Api-Version", 2);
-  xhr.onload = function() {
-    var response = JSON.parse(xhr.responseText);
-    var wayback_url = getWaybackUrlFromResponse(response);
-    if (wayback_url !== null) {
-      onsuccess(wayback_url, url);
-    } else if (onfail) {
-      onfail();
-    }
-  };
-  xhr.send(requestParams);
-}
-/**
-* @param response {object}
-* @return {string or null}
-*/
-function getWaybackUrlFromResponse(response) {
-  if (response.results &&
-    response.results[0] &&
-    response.results[0].archived_snapshots &&
-    response.results[0].archived_snapshots.closest &&
-    response.results[0].archived_snapshots.closest.available &&
-    response.results[0].archived_snapshots.closest.available === true &&
-    response.results[0].archived_snapshots.closest.status.indexOf("2") === 0 &&
-    isValidSnapshotUrl(response.results[0].archived_snapshots.closest.url)) {
-    return response.results[0].archived_snapshots.closest.url.replace(/^http:/, 'https:');
-  } else {
-    return null;
-  }
-}
-
-/**
-* Makes sure response is a valid URL to prevent code injection
-* @param url {string}
-* @return {bool}
-*/
-function isValidSnapshotUrl(url) {
-  return ((typeof url) === "string" &&
-  (url.indexOf("http://") === 0 || url.indexOf("https://") === 0));
-}
 
 function URLopener(open_url,url,wmAvailabilitycheck){
   if(wmAvailabilitycheck==true){

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,6 +1,64 @@
+/**
+ * Checks Wayback Machine API for url snapshot
+ */
+function wmAvailabilityCheck(url, onsuccess, onfail) {
+  var xhr = new XMLHttpRequest();
+  var requestUrl = 'https://archive.org/wayback/available';
+  var requestParams = 'url=' + encodeURI(url);
+  xhr.open('POST', requestUrl, true);
+  xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+  xhr.setRequestHeader('Wayback-Api-Version', 2);
+  xhr.onload = function() {
+    var response = JSON.parse(xhr.responseText);
+    var wayback_url = getWaybackUrlFromResponse(response);
+    if (wayback_url !== null) {
+      onsuccess(wayback_url, url);
+    } else if (onfail) {
+      onfail();
+    }
+  };
+  xhr.send(requestParams);
+}
+
+/**
+ * Makes sure response is a valid URL to prevent code injection
+ * @param url {string}
+ * @return {bool}
+ */
+function isValidSnapshotUrl(url) {
+  return ((typeof url) === "string" &&
+    (url.indexOf("http://") === 0 || url.indexOf("https://") === 0));
+}
+
+/**
+ * @param response {object}
+ * @return {string or null}
+ */
+function getWaybackUrlFromResponse(response) {
+  if (response.results &&
+    response.results[0] &&
+    response.results[0].archived_snapshots &&
+    response.results[0].archived_snapshots.closest &&
+    response.results[0].archived_snapshots.closest.available &&
+    response.results[0].archived_snapshots.closest.available === true &&
+    response.results[0].archived_snapshots.closest.status.indexOf("2") === 0 &&
+    isValidSnapshotUrl(response.results[0].archived_snapshots.closest.url)) {
+    return response.results[0].archived_snapshots.closest.url.replace(/^http:/, 'https:');
+  } else {
+    return null;
+  }
+}
+
 function getUrlByParameter (name) {
   const url = new URL(window.location.href)
   return url.searchParams.get(name)
 }
 
-if (typeof module !== 'undefined') { module.exports = { getUrlByParameter: getUrlByParameter } }
+if (typeof module !== 'undefined') {
+  module.exports = {
+    getUrlByParameter: getUrlByParameter,
+    getWaybackUrlFromResponse: getWaybackUrlFromResponse,
+    isValidSnapshotUrl: isValidSnapshotUrl,
+    wmAvailabilityCheck: wmAvailabilityCheck
+  }
+}


### PR DESCRIPTION
`scripts/background.js` had a function to check WBM availability `wmAvailabilityCheck()`.
`scripts/popup.js` had another function which did the SAME thing but also called SPN
in the file wasn't archived. `check_url()`.

We do the following:

Move WBM availability checking functions to `scripts/utils.js` and
modify `manifest.json` to load `scripts/utils.js` before
`background.js`.

Delete duplicate functions from `scripts/popup.js` and make it use
WBM availability checking functions from `scripts/utils.js`.

Perform additional code cleanups in `scripts/popup.js`.