### PR TITLE
Increase /books timeout limit from 10 to 30 sec

### DIFF
--- a/scripts/wikipedia.js
+++ b/scripts/wikipedia.js
@@ -113,7 +113,7 @@ function getWikipediaBooks (url) {
     beforeSend: function(jqXHR, settings) {
        jqXHR.url = settings.url;
    },
-    timeout: 10000
+    timeout: 30000
   })
 }
 


### PR DESCRIPTION
archive.org/services/context/books may need more than 10'' when there are
many books available. Its very fast as it runs background lookups in
parallel (6 threads) but still it may need more than 10''.