### PR TITLE
Replaces Save Page Now with SPN2 (web-beta)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     }
   },
   "description": "Reduce annoying 404 pages by automatically checking for an archived copy in the Wayback Machine.",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "homepage_url": "https://archive.org/",
   "icons": {
     "48": "images/icon.png",

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -507,7 +507,7 @@ chrome.contextMenus.onClicked.addListener(function (click) {
         wayback_url = 'https://web.archive.org/web/2/' + encodeURI(page_url);
       } else if (click.menuItemId === 'save') {
         wmIsAvailable = false;
-        wayback_url = 'https://web.archive.org/save/' + encodeURI(page_url);
+        wayback_url = 'https://web-beta.archive.org/save/' + encodeURI(page_url);
       } else if (click.menuItemId === 'all') {
         wmIsAvailable = false;
         wayback_url = 'https://web.archive.org/web/*/' + encodeURI(page_url);

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -57,7 +57,7 @@ function get_clean_url() {
 function save_now() {
   chrome.runtime.sendMessage({
     message: 'openurl',
-    wayback_url: 'https://web.archive.org/save/',
+    wayback_url: 'https://web-beta.archive.org/save/',
     page_url: get_clean_url(),
     method: 'save'
   }).then(handleResponse, handleError)
@@ -203,7 +203,7 @@ function auto_archive_url() {
         wmAvailabilityCheck(tab_url, onsuccess = function () { }, onfailure = function () {
           chrome.browserAction.getBadgeText({ tabId: tabId }, function (result) {
             if (result.includes('S')) {
-              fetch('https://web.archive.org/save/' + tab_url).then(function () {
+              fetch('https://web-beta.archive.org/save/' + tab_url).then(function () {
                 chrome.runtime.sendMessage({ message: 'changeBadge', tabId: tabId })
               })
             }


### PR DESCRIPTION
I can add a setting where the user can paste their access and secret keys so they won't have to sign in, but after testing it as is, it's not hard to just sign in to use SPN2 as it will prompt the user right away.  