### PR TITLE
Removes URL parameters when using Save Page Now

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -199,7 +199,8 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
   if (message.message === 'openurl') {
     var page_url = message.page_url;
     var wayback_url = message.wayback_url;
-    var url = page_url.replace(/https:\/\/web\.archive\.org\/web\/(.+?)\//g, '');
+    var url = page_url.replace(/https:\/\/web\.archive\.org\/web\/(.+?)\//g, '').replace(/\?.*/, '');
+    console.log(url);
     var open_url = wayback_url + encodeURI(url);
     if (!page_url.includes('chrome://')) {
       if (message.method !== 'save') {

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -411,7 +411,6 @@ chrome.tabs.onUpdated.addListener(function (tabId, info, tab) {
 function auto_save(tabId) {
   chrome.tabs.get(tabId, function (tab) {
     var page_url = tab.url.replace(/\?.*/, '');
-    console.log(page_url)
     if (isValidUrl(page_url) && isValidSnapshotUrl(page_url)) {
       if (!((page_url.includes("https://web.archive.org/web/")) || (page_url.includes("chrome://newtab")))) {
         wmAvailabilityCheck(page_url,

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -410,7 +410,8 @@ chrome.tabs.onUpdated.addListener(function (tabId, info, tab) {
 
 function auto_save(tabId) {
   chrome.tabs.get(tabId, function (tab) {
-    var page_url = tab.url;
+    var page_url = tab.url.replace(/\?.*/, '');
+    console.log(page_url)
     if (isValidUrl(page_url) && isValidSnapshotUrl(page_url)) {
       if (!((page_url.includes("https://web.archive.org/web/")) || (page_url.includes("chrome://newtab")))) {
         wmAvailabilityCheck(page_url,

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -200,7 +200,6 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     var page_url = message.page_url;
     var wayback_url = message.wayback_url;
     var url = page_url.replace(/https:\/\/web\.archive\.org\/web\/(.+?)\//g, '').replace(/\?.*/, '');
-    console.log(url);
     var open_url = wayback_url + encodeURI(url);
     if (!page_url.includes('chrome://')) {
       if (message.method !== 'save') {

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -194,7 +194,7 @@ function settings() {
  */
 function auto_archive_url() {
   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-    let tab_url = tabs[0].url
+    let tab_url = tabs[0].url.replace(/\?.*/, '')
     const tabId = tabs[0].id
     chrome.storage.sync.get(['auto_archive'], function (event) {
       if (event.auto_archive === true &&


### PR DESCRIPTION
Not sure if this completely addresses the issue mark raised.  I think the issue is that when auto-archive is enabled, the extension will add an 's' badge on pages that have already been archived if they have parameters.  I thought saving the page without parameters might fix it. 

Tested this change on http://example.com/?foo=bar