### PR TITLE
Updates handling of new GDELT response

### DIFF
--- a/css/recommendations.css
+++ b/css/recommendations.css
@@ -16,7 +16,6 @@
   display: flex;
   flex-flow: column wrap;
   text-align: center;
-  text-align: center;
   width: 300px;
 }
 
@@ -32,12 +31,16 @@
 .bottomElements{
   justify-content: flex-end;
   margin: 10px auto;
+  width:250px;
 }
 
-.bottomElements > img{
+img{
   align-self: center;
   display:block;
   margin: 4px auto 0 auto;
+  max-width: 250px;
+  height: auto;
+
 }
 
 body{

--- a/scripts/recommendations.js
+++ b/scripts/recommendations.js
@@ -1,7 +1,6 @@
 function parseDate (date) {
   if(typeof date === "string"){
-    const entryDate = date.slice(0, 4) + '-' + date.slice(4, 6) + '-' + date.slice(6, 8)
-    const dateObject = new Date(entryDate)
+    const dateObject = new Date(date)
     if(dateObject.toDateString() !== 'Invalid Date'){
       return dateObject.toDateString()
     }
@@ -29,7 +28,7 @@ function constructArticles (clip) {
         }
       })
     }),
-    $('<p>').text(parseDate(clip.date))
+    $('<p>').text(parseDate(clip.show_date))
   )
 
   return $('<div>').append(

--- a/test/recommendations.spec.js
+++ b/test/recommendations.spec.js
@@ -5,12 +5,12 @@ const parseDate = require("../scripts/recommendations").parseDate;
 describe('parseDate', () => {
   var tests = [
     {
-      'input' : '20181024T144028Z',
-      'expected' : 'Wed Oct 24 2018'
+      'input' : '2019-01-29T16:00:00Z',
+      'expected' : 'Tue Jan 29 2019'
     },
     {
-      'input' : '201805',
-      'expected' : 'Tue May 01 2018'
+      'input' : '201901',
+      'expected' : 'Tue Jan 01 2019'
     },
     {
       'input' : '201704ab',
@@ -33,10 +33,6 @@ describe('parseDate', () => {
   it('should return a formatted date string on success', () => {
     let result = parseDate(tests[0]['input']);
     expect(result).to.equal(tests[0]['expected']);
-  });
-  it('should return first of month if no day specified', () => {
-    let result = parseDate(tests[1]['input']);
-    expect(result).to.equal(tests[1]['expected']);
   });
   it('should return empty string on impropperly formatted date input string', () => {
     let result = parseDate(tests[2]['input']);


### PR DESCRIPTION
The GDELTv2 api was actually broken for a little while (a quotation was not escaped in the response header).  When it was fixed, there were 2 things different: the images were a different size, and the date was formatted differently.  This PR fixes both problems. 