### PR TITLE
Adds a terms of service agreement on fresh installs of the extension

### DIFF
--- a/css/welcome.css
+++ b/css/welcome.css
@@ -1,0 +1,20 @@
+body{
+  background-color: #eee;
+}
+
+#container{
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+#header{
+  text-align: center;
+  background-color: black;
+  color: white;
+  font-family:  times;
+}
+
+#content{
+  padding: 15px;
+  background-color: #fff;
+}

--- a/css/welcome.css
+++ b/css/welcome.css
@@ -18,3 +18,6 @@ body{
   padding: 15px;
   background-color: #fff;
 }
+p{
+  padding-top: 5px;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     }
   },
   "description": "Reduce annoying 404 pages by automatically checking for an archived copy in the Wayback Machine.",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "homepage_url": "https://archive.org/",
   "icons": {
     "48": "images/icon.png",
@@ -58,7 +58,6 @@
     "css/client.css"
   ],
   "browser_action": {
-    "default_icon": "images/icon.png",
-    "default_popup": "index.html"
+    "default_icon": "images/icon.png"
   }
 }

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -114,6 +114,24 @@ function URLopener(open_url, url, wmIsAvailable) {
 }
 
 /**
+ * Installed callback
+ */
+chrome.runtime.onInstalled.addListener(function(details){
+  chrome.storage.sync.get(['agreement'], function(result){
+    if(result.agreement === 'agreed'){
+      chrome.browserAction.setPopup({popup: 'index.html'});
+    }
+  })
+});
+
+chrome.browserAction.onClicked.addListener(function(tab) {
+  chrome.storage.sync.get(['agreement'], function(result){
+    if(result.agreement !== 'agreed'){
+      chrome.tabs.create({url:chrome.runtime.getURL('welcome.html')})
+    }
+  })
+});
+/**
  * Close window callback
  */
 chrome.windows.onRemoved.addListener(function (id) {

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -125,11 +125,7 @@ chrome.runtime.onInstalled.addListener(function(details){
 });
 
 chrome.browserAction.onClicked.addListener(function(tab) {
-  chrome.storage.sync.get(['agreement'], function(result){
-    if(result.agreement !== 'agreed'){
-      chrome.tabs.create({url:chrome.runtime.getURL('welcome.html')})
-    }
-  })
+  chrome.windows.create({url:chrome.runtime.getURL('welcome.html'), width: 600, height:800, top: 0})
 });
 /**
  * Close window callback

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -18,6 +18,7 @@ function restore_options () {
     doi: false,
     news: false,
     agreement: false,
+    optout:false,
     wikibooks: false,
     showall: false
   }, function (items) {
@@ -34,6 +35,7 @@ function restore_options () {
     $('#showall').prop('checked', items.showall)
     $('#news').prop('checked', items.news)
     $('#agreement').prop('checked', items.agreement)
+    $('#optout').prop('checked', items.optout)
     $('#wikibooks').prop('checked', items.wikibooks)
     $('#doi').prop('checked', items.doi)
   })
@@ -54,6 +56,7 @@ function save_options () {
     showall : $('#showall').prop('checked'),
     news : $('#news').prop('checked'),
     agreed : $('#agreement').prop('checked'),
+    optout: $('#optout').prop('checked'),
     wikibooks : $('#wikibooks').prop('checked'),
     doi : $('#doi').prop('checked')
   }, function () {

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -17,6 +17,7 @@ function restore_options () {
     tagcloud: false,
     doi: false,
     news: false,
+    agreement: false,
     wikibooks: false,
     showall: false
   }, function (items) {
@@ -32,6 +33,7 @@ function restore_options () {
     $('#tagcloud').prop('checked', items.tagcloud)
     $('#showall').prop('checked', items.showall)
     $('#news').prop('checked', items.news)
+    $('#agreement').prop('checked', items.agreement)
     $('#wikibooks').prop('checked', items.wikibooks)
     $('#doi').prop('checked', items.doi)
   })
@@ -51,10 +53,17 @@ function save_options () {
     tagcloud : $('#tagcloud').prop('checked'),
     showall : $('#showall').prop('checked'),
     news : $('#news').prop('checked'),
+    agreed : $('#agreement').prop('checked'),
     wikibooks : $('#wikibooks').prop('checked'),
     doi : $('#doi').prop('checked')
   }, function () {
     $('#save').toggleClass('btn-success btn-primary').text('Saved').delay(500).fadeOut(300, function() {
+      if($('#agreement').prop('checked') === false){
+        chrome.browserAction.setPopup({popup: ''});
+        chrome.browserAction.onClicked.addListener(function(tab) {
+            chrome.tabs.create({url:chrome.runtime.getURL('welcome.html')})
+        });
+      }
       window.close()
     });
   })

--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -1,6 +1,6 @@
 $(document).ready(function () {
   $('#accept').click(function () {
-    chrome.storage.sync.set({ 'agreement': 'agreed' }, function () {
+    chrome.storage.sync.set({ 'agreement': true }, function () {
       chrome.browserAction.setPopup({ popup: 'index.html' }, function () {
         window.close()
       })

--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -1,0 +1,12 @@
+$(document).ready(function () {
+  $('#accept').click(function () {
+    chrome.storage.sync.set({ 'agreement': 'agreed' }, function () {
+      chrome.browserAction.setPopup({ popup: 'index.html' }, function () {
+        window.close()
+      })
+    })
+  })
+  $('#decline').click(function () {
+    window.close()
+  })
+})

--- a/settings.html
+++ b/settings.html
@@ -59,6 +59,10 @@
 							<input type="checkbox" id="news">
 							<span class="enable"><strong>Suggest TV Clips related to online News Articles</strong></span>
 						</label>
+						<label for="agreement">
+							<input type="checkbox" id="agreement">
+							<span class="enable"><strong>Agree to Terms of Service</strong></span>
+						</label>
 					</div>
 
 					<h3><strong>Window Settings</strong></h3>

--- a/settings.html
+++ b/settings.html
@@ -63,6 +63,10 @@
 							<input type="checkbox" id="agreement">
 							<span class="enable"><strong>Agree to Terms of Service</strong></span>
 						</label>
+						<label for="optout">
+							<input type="checkbox" id="optout">
+							<span class="enable"><strong>Opt out of sharing data with the Internet Archive</strong></span>
+						</label>
 					</div>
 
 					<h3><strong>Window Settings</strong></h3>

--- a/welcome.html
+++ b/welcome.html
@@ -29,8 +29,8 @@
         </button>
       </div>
     </div>
+    <script src="scripts/utils.js"></script>
+    <script src="scripts/build.js"></script>
+    <script src="scripts/welcome.js"></script>
   </body>
 </html>
-<script src="scripts/utils.js"></script>
-<script src="scripts/build.js"></script>
-<script src="scripts/welcome.js"></script>

--- a/welcome.html
+++ b/welcome.html
@@ -3,7 +3,7 @@
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
     <meta content="utf-8" http-equiv="encoding">
-    <title>Welcome!</title>
+    <title>Welcome to the Internet Archive's Wayback Machine Extension!</title>
     <link rel="icon" type="image/ico" href="images/icon.png" />
 
     <link rel="stylesheet" type="text/css" href="css/style.css">
@@ -19,7 +19,7 @@
       <div id="content">
         <h1>Welcome!</h1>
         <p>Here’s your brand new Internet Archive browser extension.</p>
-        <p>The extension collects and stores information about the search queries you make and the web pages you view to provide you with information about those pages and to help Internet Archive measure the Web. In some cases, information collected by the extension may be personally identifiable, but we do not attempt to analyze any information collected by the extension to determine the identity of any user.</p>
+        <p>The extension collects and stores information about the search queries you make and the web pages you view to provide you with information about those pages and to help The Wayback Machine archive the Web. In some cases, information collected by the extension may be personally identifiable, but we do not attempt to analyze any information collected by the extension to determine the identity of any user.</p>
         <p>Read and accept the <a href="https://archive.org/about/terms.php">Internet Archive Terms of Use and Privacy Policy</a></p>
         <button type="submit" name="acceptTerms" id="accept" class="btn btn-success">
           <span>Accept and Enable</span>

--- a/welcome.html
+++ b/welcome.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
+    <title>Welcome!</title>
+    <link rel="icon" type="image/ico" href="images/icon.png" />
+
+    <link rel="stylesheet" type="text/css" href="css/style.css">
+    <link rel="stylesheet" type="text/css" href="css/common.css">
+    <link rel="stylesheet" type="text/css" href="css/welcome.css">
+
+  </head>
+  <body>
+    <div id="container">
+      <div id="header">
+        <h1>Internet <img src="images/icon.png" alt="Internet Archive"> Archive</h1>
+      </div>
+      <div id="content">
+        <h1>Welcome!</h1>
+        <p>Here’s your brand new Internet Archive browser extension.</p>
+        <p>The extension collects and stores information about the search queries you make and the web pages you view to provide you with information about those pages and to help Internet Archive measure the Web. In some cases, information collected by the extension may be personally identifiable, but we do not attempt to analyze any information collected by the extension to determine the identity of any user.</p>
+        <p>Read and accept the <a href="https://archive.org/about/terms.php">Internet Archive Terms of Use and Privacy Policy</a></p>
+        <button type="submit" name="acceptTerms" id="accept" class="btn btn-success">
+          <span>Accept and Enable</span>
+        </button>
+        <button type="submit" name="declineTerms" id="decline" class="btn btn-warning">
+          <span>Cancel</span>
+        </button>
+      </div>
+    </div>
+  </body>
+</html>
+<script src="scripts/utils.js"></script>
+<script src="scripts/build.js"></script>
+<script src="scripts/welcome.js"></script>


### PR DESCRIPTION
Mark wanted a similar ToS agreement to the [Alexa Internet Extension](https://chrome.google.com/webstore/detail/alexa-traffic-rank/cknebhggccemgcnbidipinkifmmegdel?hl=en).  

It's functioning properly if on a fresh install, when you click the extension icon, it opens a new tab with a ToS agreement.  If you click agree, it sets the default popup back to index.html. Else, it just closes the window and doesn't change the browserAction behavior.  

The things I'd like to get feedback on:
- Any bugs?
- Style/Content of the ToS page
- Should I give any UI feedback for clicking agree or cancel? 
    - Right now, either option just closes the window.
    - The Alexa Internet extension redirects to a "success" page on agree. 