### PR TITLE
Fixed improper usage of "isNotExcludedUrl" 

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -447,7 +447,7 @@ chrome.tabs.onUpdated.addListener(function (tabId, info, tab) {
 
 function auto_save(tabId, url) {
   var page_url = url.replace(/\?.*/, '');
-  if (isValidUrl(page_url) && ! isNotExcludedUrl(page_url)) {
+  if (isValidUrl(page_url) && isNotExcludedUrl(page_url)) {
     wmAvailabilityCheck(page_url,
       function () {
         chrome.browserAction.getBadgeText({ tabId: tabId }, function (result) {


### PR DESCRIPTION
The function isNotExcludedUrl returns true if the URL is not excluded, false if it is excluded. In function **auto_save** , !isNotExcludedUrl is being used, when it is to be just isNotExcludedUrl.
This was causing a bug wherein BadgeText "S" was not being added to the icon, when the page had not been archived.