### PR TITLE
Fixing Issue/314: amazon books now will only make one request

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -417,6 +417,8 @@ chrome.tabs.onUpdated.addListener(function (tabId, info, tab) {
                   if (('metadata' in resp && 'identifier' in resp['metadata']) ||
                     'ocaid' in resp) {
                     chrome.browserAction.setBadgeText({ tabId: tabId, text: 'B' })
+                    // Storing the tab url as well as the fetched archive url for future use
+                    chrome.storage.sync.set({ 'tab_url': url, 'detail_url': resp['metadata']['identifier-access']  }, function () {})
                   }
                 })
             }

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -416,6 +416,7 @@ chrome.tabs.onUpdated.addListener(function (tabId, info, tab) {
                 .then(resp => {
                   if (('metadata' in resp && 'identifier' in resp['metadata']) ||
                     'ocaid' in resp) {
+                    console.log('making request in background.js')
                     chrome.browserAction.setBadgeText({ tabId: tabId, text: 'B' })
                     // Storing the tab url as well as the fetched archive url for future use
                     chrome.storage.sync.set({ 'tab_url': url, 'detail_url': resp['metadata']['identifier-access']  }, function () {})

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -416,7 +416,6 @@ chrome.tabs.onUpdated.addListener(function (tabId, info, tab) {
                 .then(resp => {
                   if (('metadata' in resp && 'identifier' in resp['metadata']) ||
                     'ocaid' in resp) {
-                    console.log('making request in background.js')
                     chrome.browserAction.setBadgeText({ tabId: tabId, text: 'B' })
                     // Storing the tab url as well as the fetched archive url for future use
                     chrome.storage.sync.set({ 'tab_url': url, 'detail_url': resp['metadata']['identifier-access']  }, function () {})

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -209,16 +209,13 @@ function borrow_books() {
           let stored_url = result.tab_url
           let detail_url = result.detail_url
           // Checking if the tab url is the same as the last stored one
-          console.log(stored_url, url, detail_url)
           if (stored_url === url) {
-            console.log('no request making in popup.js')
             // if so, then we can use the previously fetched url
             $('#borrow_books_tr').css({ 'display': 'block' }).click(function () {
               chrome.tabs.create({ url: detail_url })
             })
           } else {
             // if not, we can then fetch it again
-            console.log('making request in popup.js', url)
             get_amazonbooks(url).then(response => {
               if (response['metadata'] && response['metadata']['identifier-access']) {
                 let details_url = response['metadata']['identifier-access']

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -205,17 +205,20 @@ function borrow_books() {
     tabId = tabs[0].id
     chrome.browserAction.getBadgeText({ tabId: tabId }, function (result) {
       if (result.includes('B') && url.includes('www.amazon') && url.includes('/dp/')) {
-        chrome.storage.sync.get(['bg_url'], function (result) { 
-          let stored_url = result.bg_url
+        chrome.storage.sync.get(['tab_url', 'detail_url'], function (result) { 
+          let stored_url = result.tab_url
           let detail_url = result.detail_url
           // Checking if the tab url is the same as the last stored one
+          console.log(stored_url, url, detail_url)
           if (stored_url === url) {
+            console.log('no request making in popup.js')
             // if so, then we can use the previously fetched url
             $('#borrow_books_tr').css({ 'display': 'block' }).click(function () {
               chrome.tabs.create({ url: detail_url })
             })
           } else {
             // if not, we can then fetch it again
+            console.log('making request in popup.js', url)
             get_amazonbooks(url).then(response => {
               if (response['metadata'] && response['metadata']['identifier-access']) {
                 let details_url = response['metadata']['identifier-access']

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -205,14 +205,27 @@ function borrow_books() {
     tabId = tabs[0].id
     chrome.browserAction.getBadgeText({ tabId: tabId }, function (result) {
       if (result.includes('B') && url.includes('www.amazon') && url.includes('/dp/')) {
-        get_amazonbooks(url).then(response => {
-          if (response['metadata'] && response['metadata']['identifier-access']) {
-            let details_url = response['metadata']['identifier-access']
+        chrome.storage.sync.get(['bg_url'], function (result) { 
+          let stored_url = result.bg_url
+          let detail_url = result.detail_url
+          // Checking if the tab url is the same as the last stored one
+          if (stored_url === url) {
+            // if so, then we can use the previously fetched url
             $('#borrow_books_tr').css({ 'display': 'block' }).click(function () {
-              chrome.tabs.create({ url: details_url })
+              chrome.tabs.create({ url: detail_url })
+            })
+          } else {
+            // if not, we can then fetch it again
+            get_amazonbooks(url).then(response => {
+              if (response['metadata'] && response['metadata']['identifier-access']) {
+                let details_url = response['metadata']['identifier-access']
+                $('#borrow_books_tr').css({ 'display': 'block' }).click(function () {
+                  chrome.tabs.create({ url: details_url })
+                })
+              }
             })
           }
-        })
+        })  
       }
     })
   })


### PR DESCRIPTION
@MaxReinisch @anishsarangi 
**Explanation of the previous bug:** 
Since Chrome browser will cache your page, once we switch back to the tabs which we have already requested, chrome will not update the tab hence ```fetch``` will not execute. In this situation, the url stored in the chrome storage will not be updated as well so we will see that the extension is fetching the previous book.

Sorry about the fact that I am still using chrome storage to implement it this time because it is the easiest way to get shared data across all extension files in my opinion. Besides, I will only store two key-value pairs so memory throttling might not be a problem here.  

**Current solution:** 
For each request from ```background.js```, I store two key-value pairs, which are the tab url and the fetched archive url. Once the badgeText has B in it, then we can check if the current tab url is what we have stored just now. If so, then it means that the current tab is not using cache and our archive url is valid to use. Otherwise, it means that this page is using cache hence not making a new fetch request to update the chrome storage. So this time we can make a request from ```popup.js``` to get the new archive url. (In my opinion, this request is not a redundant request since we can not store the archive url for each request)

Let me know if there is any bug this time! I have tested for switching among 4 pages and it works fine. But maybe there is some other situations I haven't think about yet.