### PR TITLE
Context options refurbish

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,3 @@
 {
-    "extends": "standard"
+    "extends": "eslint:recommended"
 }

--- a/css/index.css
+++ b/css/index.css
@@ -5,28 +5,80 @@ li{
     margin:0px 0px 0px -18px;
     padding: 0px;
 }
+
+.show_context_options {
+    display: block !important;
+    background: #F4F4F4;
+    text-align: left;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 5px;
+    padding-bottom: 1px;
+}
+
+.show_context_options button {
+    margin-bottom: 5px !important;
+}
+
+.show_context_options p {
+    margin: 0;
+}
+
+.show_context_options label {
+    font-weight: normal;
+}
+
+.show_context_options span {
+    margin-left: 5px;
+}
+
+.hide_context_options {
+    display: none;
+}
+
+.icon_dropdown {
+    position: absolute;
+    right: 12px;
+    top: 11px;
+}
+
+.tranform_icon_dropdown {
+    -webkit-transform: rotate(180deg);     /* Chrome and other webkit browsers */
+    -moz-transform: rotate(180deg);        /* FF */
+    -o-transform: rotate(180deg);          /* Opera */
+    -ms-transform: rotate(180deg);         /* IE9 */
+    transform: rotate(180deg);             /* W3C compliant browsers */
+    transition: transform 0.5s linear;
+    /* IE8 and below */
+    filter: progid:DXImageTransform.Microsoft.Matrix(M11=-1, M12=0, M21=0, M22=-1, DX=0, DY=0, SizingMethod='auto expand');
+}
+
+.context_feature {
+    position: relative;
+}
+
 #horizontal_line{
-    margin: 0px; 
-    padding: 0px; 
-    border: 0px solid rgb(6, 117, 211); 
+    margin: 0px;
+    padding: 0px;
+    border: 0px solid rgb(6, 117, 211);
     font-size: 19px; font-style: inherit;
-    font-variant: inherit; 
-    font-weight: inherit; 
-    font-stretch: inherit; 
-    line-height: 1; 
-    font-family: sans-serif; 
-    vertical-align: baseline; 
-    box-sizing: content-box; 
-    overflow: unset; 
-    height: 1px; 
-    position: relative; 
-    width: auto; 
-    display: flex; 
-    background-color: rgb(9, 150, 248); color: rgb(255, 255, 255); 
-    text-align: left; 
-    align-items: center; 
-    border-radius: 3px; 
-    justify-content: center; 
+    font-variant: inherit;
+    font-weight: inherit;
+    font-stretch: inherit;
+    line-height: 1;
+    font-family: sans-serif;
+    vertical-align: baseline;
+    box-sizing: content-box;
+    overflow: unset;
+    height: 1px;
+    position: relative;
+    width: auto;
+    display: flex;
+    background-color: rgb(9, 150, 248); color: rgb(255, 255, 255);
+    text-align: left;
+    align-items: center;
+    border-radius: 3px;
+    justify-content: center;
     text-decoration: none;
 }
 

--- a/index.html
+++ b/index.html
@@ -37,9 +37,51 @@
           Map</button>
         <button type="button" class="btn btn-sm btn-block extra_feature" id="search_tweet" tabindex="-1">
           <i class="fa fa-twitter"></i> Tweets About this Page</button>
+        <!--<div id="display_">-->
+          <!--<button type="button" class="btn btn-sm btn-block context_feature" id="context-screen">Show Me Context</button>-->
+        <!--</div>-->
+
         <div id="display_">
-          <button type="button" class="btn btn-sm btn-block context_feature" id="context-screen">Show Me Context</button>
+          <button type="button" class="btn btn-sm btn-block context_feature" id="show_context_options" ontoggle="show_context_options()">
+            Context options
+            <svg width="12" height="7" viewBox="0 0 12 7" fill="#FFF" xmlns="http://www.w3.org/2000/svg" class="icon_dropdown">
+              <path d="M9.4625 0.292486L5.5825 4.17249L1.7025 0.292486C1.51567 0.105233 1.26202 0 0.9975 0C0.732982 0 0.479332 0.105233 0.2925 0.292486C-0.0975 0.682486 -0.0975 1.31249 0.2925 1.70249L4.8825 6.29249C5.2725 6.68249 5.9025 6.68249 6.2925 6.29249L10.8825 1.70249C11.2725 1.31249 11.2725 0.682486 10.8825 0.292486C10.4925 -0.0875144 9.8525 -0.0975144 9.4625 0.292486V0.292486Z" fill="white"/>
+            </svg>
+          </button>
+          <div id="context-options" class="hide_context_options">
+            <label for="alexa">
+                <input type="checkbox" name="context" id="alexa" class="only">
+                <span class="enable">Alexa Internet</span>
+            </label>
+            <label for="domaintools">
+                <input type="checkbox" name="context" id="domaintools" class="only">
+                <span class="enable">Domain tools</span>
+            </label>
+            <label for="tweets">
+                <input type="checkbox" name="context" id="tweets" class="only">
+                <span class="enable">Tweets of URLs</span>
+            </label>
+            <label for="wbmsummary">
+                <input type="checkbox" name="context" id="wbmsummary" class="only">
+                <span class="enable">Wayback Summary</span>
+            </label>
+            <label for="annotations">
+                <input type="checkbox" name="context" id="annotations" class="only">
+                <span class="enable">Annotations</span>
+            </label>
+            <label for="tagcloud">
+                <input type="checkbox" name="context" id="tagcloud" class="only">
+                <span class="enable">Word Cloud of Sites</span>
+            </label>
+            <label for="showall">
+                <input type="checkbox" id="showall">
+                <span class="enable">Select all</span>
+            </label>
+            <button type="button" class="btn btn-sm btn-block context_feature" id="context-screen">Show Context
+            </button>
+          </div>
         </div>
+
         <div id="borrow_books_tr" style="display: none;">
           <button type="button" class="btn btn-warning btn-sm btn-block" id="borrow_books" tabindex='-1'>Read This Book</button>
         </div>
@@ -82,3 +124,4 @@
 <script src="scripts/utils.js"></script>
 <script src="scripts/amazon.js"></script>
 <script src="scripts/popup.js"></script>
+<script src="scripts/settings.js"></script>

--- a/scripts/booklist.js
+++ b/scripts/booklist.js
@@ -1,56 +1,66 @@
 function populateBooks(url) {
-  // Gets the data for each book on the wikipedia url
-  getWikipediaBooks(url).then(data=>{
-    $(".loader").hide();
-    // No need to check the validation of data since promise is already being resolved
-    for(let isbn of Object.keys(data)) {  // Iterate over each book to get data
-      let metadata = getMetadata(data[isbn]);
-      if (metadata){
-        let book_element = addBook(metadata);
-        if(metadata.readable){
-          $("#resultsTray").prepend(book_element);
-        } else {
-          $("#resultsTray").append(book_element);
+    // Gets the data for each book on the wikipedia url
+    getWikipediaBooks(url).then(data => {
+        $(".loader").hide();
+        // No need to check the validation of data since promise is already being resolved
+        for (let isbn of Object.keys(data)) {  // Iterate over each book to get data
+            let metadata = getMetadata(data[isbn]);
+            if (metadata) {
+                let book_element = addBook(metadata);
+                if (metadata.readable) {
+                    $("#resultsTray").prepend(book_element);
+                } else {
+                    $("#resultsTray").append(book_element);
+                }
+            }
         }
-      }
-    }
-  }).catch( function(error) {
-    $(".loader").hide();
-    $("#resultsTray").css("grid-template-columns", "none").append(
-      $("<div>").html(error)
+    }).catch(function (error) {
+        $(".loader").hide();
+        $("#resultsTray").css("grid-template-columns", "none").append(
+            $("<div>").html(error)
+        );
+    });
+}
+
+function addBook(metadata) {
+    let text_elements = $("<div>").attr({"class": "text_elements"}).append(
+        $("<p>").append($("<strong>").text(metadata.title)),
+        $("<p>").text(metadata.author)
     );
-  });
-}
-
-function addBook(metadata){
-  let text_elements = $("<div>").attr({"class": "text_elements"}).append(
-    $("<p>").append($("<strong>").text(metadata.title)),
-    $("<p>").text(metadata.author)
-  );
-  let details = $("<div>").attr({"class": "bottom_details"}).append(
-    metadata.image ? $("<img>").attr({"class": "cover-img", "src": metadata.image}) : $("<p>").attr({"class": "cover-img"}).text("No cover available"),
-    $("<button>").attr({"class": metadata.button_class}).text(metadata.button_text).click(function(){
-      chrome.storage.sync.get(['show_context'],function(event1){
-          if(event1.show_context==undefined){
-              event1.show_context="tab";
-          }
-          if(event1.show_context=="tab"){
-              chrome.tabs.create({url:metadata.link});
-          }else{
-            chrome.system.display.getInfo(function(displayInfo){
-              let height = displayInfo[0].bounds.height;
-              let width = displayInfo[0].bounds.width;
-              chrome.windows.create({url:metadata.link, width:width/2, height:height, top:0, left:0, focused:true});
+    let details = $("<div>").attr({"class": "bottom_details"}).append(
+        metadata.image ? $("<img>").attr({
+            "class": "cover-img",
+            "src": metadata.image
+        }) : $("<p>").attr({"class": "cover-img"}).text("No cover available"),
+        $("<button>").attr({"class": metadata.button_class}).text(metadata.button_text).click(function () {
+            chrome.storage.sync.get(['show_context'], function (event1) {
+                if (event1.show_context == undefined) {
+                    event1.show_context = "tab";
+                }
+                if (event1.show_context == "tab") {
+                    chrome.tabs.create({url: metadata.link});
+                } else {
+                    chrome.system.display.getInfo(function (displayInfo) {
+                        let height = displayInfo[0].bounds.height;
+                        let width = displayInfo[0].bounds.width;
+                        chrome.windows.create({
+                            url: metadata.link,
+                            width: width / 2,
+                            height: height,
+                            top: 0,
+                            left: 0,
+                            focused: true
+                        });
+                    });
+                }
             });
-          }
-      });
-    })
-  );
-  return $("<div>").append(text_elements, details);
+        })
+    );
+    return $("<div>").append(text_elements, details);
 }
 
-if(typeof module !=="undefined") {
-  module.exports = {
-    getMetadata:getMetadata
-  };
+if (typeof module !== "undefined") {
+    module.exports = {
+        getMetadata: getMetadata
+    };
 }

--- a/scripts/citations.js
+++ b/scripts/citations.js
@@ -15,114 +15,117 @@
 //   findCitations()
 // })
 
-function findCitations () {
-  let candidates = $("a[href^='#_ftnref']").parent()
-  for (let i = 0; i < candidates.length; i++) {
-    let citation = getCitation(candidates[i].innerText || candidates[i].textContent)
-    if (citation) {
-      advancedSearch(citation, candidates[i])
+function findCitations() {
+    let candidates = $("a[href^='#_ftnref']").parent()
+    for (let i = 0; i < candidates.length; i++) {
+        let citation = getCitation(candidates[i].innerText || candidates[i].textContent)
+        if (citation) {
+            advancedSearch(citation, candidates[i])
+        }
     }
-  }
 }
 
-function getCitation (cit) {
-  str = cit.replace(/^[^a-zA-Z]*/, '')
-  if (str.length == 0) {
-    return null
-  } else {
-    let publisher = str.match(/\(.*\d\d\d\d\)/)[0]
-    let halves = str.split(publisher)
-    let pages = halves[1].split(',').filter($.isNumeric).map(Number)
-    let commaLoc = halves[0].indexOf(',')
-    let title, author
-    if (commaLoc >= 0) {
-      author = halves[0].slice(0, commaLoc)
-      title = halves[0].slice(commaLoc + 1)
+function getCitation(cit) {
+    str = cit.replace(/^[^a-zA-Z]*/, '')
+    if (str.length == 0) {
+        return null
     } else {
-      author = null
-      title = halves[0]
+        let publisher = str.match(/\(.*\d\d\d\d\)/)[0]
+        let halves = str.split(publisher)
+        let pages = halves[1].split(',').filter($.isNumeric).map(Number)
+        let commaLoc = halves[0].indexOf(',')
+        let title, author
+        if (commaLoc >= 0) {
+            author = halves[0].slice(0, commaLoc)
+            title = halves[0].slice(commaLoc + 1)
+        } else {
+            author = null
+            title = halves[0]
+        }
+        return {
+            title: title.replace(/^\s/, '').replace(/\s$/, ''),
+            author: author,
+            pages: pages,
+            publisher: publisher.slice(1, -1)
+
+        }
     }
-    return {
-      title: title.replace(/^\s/, '').replace(/\s$/, ''),
-      author: author,
-      pages: pages,
-      publisher: publisher.slice(1, -1)
+}
 
+function getAdvancedSearchQuery(parsed_cit) {
+    ({author, title} = parsed_cit)
+    // format author
+    if (author) {
+        author = formatAuthor(author)
+        return 'creator:' + author + ' AND title:"' + title + '"'
+    } else {
+        return 'title:"' + title + '"'
     }
-  }
 }
 
-function getAdvancedSearchQuery (parsed_cit) {
-  ({ author, title } = parsed_cit)
-  // format author
-  if (author){
-    author = formatAuthor(author)
-    return 'creator:' + author + ' AND title:"' + title + '"'
-  }else{
-    return 'title:"' + title +'"'
-  }
+function formatAuthor(auth) { //todo: handle multiple authors
+    return auth.replace(' and ', ' ')
 }
 
-function formatAuthor (auth) { //todo: handle multiple authors
-  return auth.replace(' and ', ' ')
+function advancedSearch(citation, cand) {
+    query = getAdvancedSearchQuery(citation)
+    chrome.runtime.sendMessage({
+        message: 'citationadvancedsearch',
+        query: query
+    }, function (identifier) {
+        if (identifier) {
+            insertLink(getUrlFromIdentifier(identifier, citation), cand)
+        }
+        // $(cand).html(
+        //   cand.innerHTML.replace('<em>', '<a href="https://archive.org/details/' + identifier + pagestring + '"><em>').replace('</em>', '</em></a>')
+        // )
+    })
 }
 
-function advancedSearch (citation, cand) {
-  query = getAdvancedSearchQuery(citation)
-  chrome.runtime.sendMessage({
-    message: 'citationadvancedsearch',
-    query: query
-  }, function(identifier){
-    if(identifier){
-      insertLink(getUrlFromIdentifier(identifier, citation), cand)
+function getUrlFromIdentifier(identifier, citation) {
+    let pagestring = ''
+    if (citation.pages) {
+        pagestring = '/page/' + citation.pages[0]
     }
-    // $(cand).html(
-    //   cand.innerHTML.replace('<em>', '<a href="https://archive.org/details/' + identifier + pagestring + '"><em>').replace('</em>', '</em></a>')
-    // )
-  })
+    let url = 'https://archive.org/details/' + identifier + pagestring
+    return url
 }
-function getUrlFromIdentifier(identifier, citation){
-  let pagestring = ''
-  if (citation.pages) {
-    pagestring = '/page/' + citation.pages[0]
-  }
-  let url = 'https://archive.org/details/' + identifier + pagestring
-  return url
+
+function insertLink(url, cand) {
+    $(cand).html(
+        cand.innerHTML.replace('<em>', '<a target="_blank" href="' + url + '"><em>').replace('</em>', '</em></a>')
+    )
 }
-function insertLink(url, cand){
-  $(cand).html(
-    cand.innerHTML.replace('<em>', '<a target="_blank" href="'+url+'"><em>').replace('</em>', '</em></a>')
-  )
-}
-  // let host = 'https://archive.org/advancedsearch.php?q='
-  // let endsearch = '&fl%5B%5D=identifier&sort%5B%5D=&sort%5B%5D=&sort%5B%5D=&rows=50&page=1&output=json&save=yes'
-  // let url = host + query + endsearch
-  // $.ajax({
-  //   url: url,
-  //   type: 'GET',
-  //   dataType: 'json',
-  //   crossDomain: true,
-  //   jsonp: 'callback'
-  // })
-  // .done(function (data) {
-  //   if (data.response.docs.length > 0) {
-  //     let identifier = data.response.docs[0].identifier
-  //     let pagestring = ''
-  //     if (citation.pages) {
-  //       pagestring = '/page/' + citation.pages[0]
-  //     }
-  //     $(cand).html(
-  //       cand.innerHTML.replace('<em>', '<a href="https://archive.org/details/' + identifier + pagestring + '"><em>').replace('</em>', '</em></a>')
-  //     )
-  //   }
-  // })
-  // .fail(function (err) {
-  //   console.log(err)
-  // })
+
+// let host = 'https://archive.org/advancedsearch.php?q='
+// let endsearch = '&fl%5B%5D=identifier&sort%5B%5D=&sort%5B%5D=&sort%5B%5D=&rows=50&page=1&output=json&save=yes'
+// let url = host + query + endsearch
+// $.ajax({
+//   url: url,
+//   type: 'GET',
+//   dataType: 'json',
+//   crossDomain: true,
+//   jsonp: 'callback'
+// })
+// .done(function (data) {
+//   if (data.response.docs.length > 0) {
+//     let identifier = data.response.docs[0].identifier
+//     let pagestring = ''
+//     if (citation.pages) {
+//       pagestring = '/page/' + citation.pages[0]
+//     }
+//     $(cand).html(
+//       cand.innerHTML.replace('<em>', '<a href="https://archive.org/details/' + identifier + pagestring + '"><em>').replace('</em>', '</em></a>')
+//     )
+//   }
+// })
+// .fail(function (err) {
+//   console.log(err)
+// })
 
 if (typeof module !== 'undefined') {
-  module.exports = {
-    getCitation: getCitation,
-    getAdvancedSearchQuery:getAdvancedSearchQuery
-  }
+    module.exports = {
+        getCitation: getCitation,
+        getAdvancedSearchQuery: getAdvancedSearchQuery
+    }
 }

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -210,7 +210,7 @@ function borrow_books() {
     tabId = tabs[0].id
     chrome.browserAction.getBadgeText({ tabId: tabId }, function (result) {
       if (result.includes('B') && url.includes('www.amazon') && url.includes('/dp/')) {
-        chrome.storage.sync.get(['tab_url', 'detail_url'], function (result) { 
+        chrome.storage.sync.get(['tab_url', 'detail_url'], function (result) {
           let stored_url = result.tab_url
           let detail_url = result.detail_url
           // Checking if the tab url is the same as the last stored one
@@ -230,7 +230,7 @@ function borrow_books() {
               }
             })
           }
-        })  
+        })
       }
     })
   })
@@ -308,6 +308,12 @@ function show_wikibooks() {
   })
 }
 
+// Show context options
+function show_context_options() {
+  $('#context-options').toggleClass("show_context_options");
+  $('.icon_dropdown').toggleClass("tranform_icon_dropdown");
+}
+
 window.onloadFuncs = [get_url, borrow_books, show_news, show_wikibooks]
 window.onload = function () {
   for (var i in this.onloadFuncs) {
@@ -330,3 +336,4 @@ $('.feedback').click(open_feedback_page)
 $('#overview').click(view_all)
 $('#make_modal').click(makeModal)
 $('#search_input').keydown(display_suggestions)
+$('#show_context_options').click(show_context_options)

--- a/settings.html
+++ b/settings.html
@@ -63,47 +63,47 @@
 				</div>
 			</div>
 
-			<div id="context_options"  class="col-sm-5 col-sm-offset-1">
-				<div class="column">
-					<h3><strong>"Show me Context" Features</strong></h3>
-					<div class="settings">
-						<label for="alexa">
-							<input type="checkbox" name="context" id="alexa" class="only">
-							<span class="enable"><strong>Alexa Internet</strong></span>
-						</label>
-						<br>
-						<label for="domaintools">
-							<input type="checkbox" name="context" id="domaintools" class="only">
-							<span class="enable"><strong>DomainTools</strong></span>
-						</label>
-						<br>
-						<label for="tweets">
-							<input type="checkbox" name="context" id="tweets" class="only">
-							<span class="enable"><strong>Tweets of URLs</strong></span>
-						</label>
-						<br>
-						<label for="wbmsummary">
-							<input type="checkbox" name="context" id="wbmsummary" class="only">
-							<span class="enable"><strong>Wayback Machine Summary</strong></span>
-						</label>
-						<br>
-						<label for="annotations">
-							<input type="checkbox" name="context" id="annotations" class="only">
-							<span class="enable"><strong>Annotations with Hypothes.is</strong></span>
-						</label>
-						<br>
-						<label for="tagcloud">
-							<input type="checkbox" name="context" id="tagcloud" class="only">
-							<span class="enable"><strong>Word Cloud for Sites</strong></span>
-						</label>
-						<br>
-						<label for="showall">
-							<input type="checkbox" id="showall">
-							<span class="enable"><strong>Show All Context Screens</strong></span>
-						</label>
-					</div>
-				</div>
-			</div>
+			<!--<div id="context_options"  class="col-sm-5 col-sm-offset-1">-->
+				<!--<div class="column">-->
+					<!--<h3><strong>"Show me Context" Features</strong></h3>-->
+					<!--<div class="settings">-->
+						<!--<label for="alexa">-->
+							<!--<input type="checkbox" name="context" id="alexa" class="only">-->
+							<!--<span class="enable"><strong>Alexa Internet</strong></span>-->
+						<!--</label>-->
+						<!--<br>-->
+						<!--<label for="domaintools">-->
+							<!--<input type="checkbox" name="context" id="domaintools" class="only">-->
+							<!--<span class="enable"><strong>DomainTools</strong></span>-->
+						<!--</label>-->
+						<!--<br>-->
+						<!--<label for="tweets">-->
+							<!--<input type="checkbox" name="context" id="tweets" class="only">-->
+							<!--<span class="enable"><strong>Tweets of URLs</strong></span>-->
+						<!--</label>-->
+						<!--<br>-->
+						<!--<label for="wbmsummary">-->
+							<!--<input type="checkbox" name="context" id="wbmsummary" class="only">-->
+							<!--<span class="enable"><strong>Wayback Machine Summary</strong></span>-->
+						<!--</label>-->
+						<!--<br>-->
+						<!--<label for="annotations">-->
+							<!--<input type="checkbox" name="context" id="annotations" class="only">-->
+							<!--<span class="enable"><strong>Annotations with Hypothes.is</strong></span>-->
+						<!--</label>-->
+						<!--<br>-->
+						<!--<label for="tagcloud">-->
+							<!--<input type="checkbox" name="context" id="tagcloud" class="only">-->
+							<!--<span class="enable"><strong>Word Cloud for Sites</strong></span>-->
+						<!--</label>-->
+						<!--<br>-->
+						<!--<label for="showall">-->
+							<!--<input type="checkbox" id="showall">-->
+							<!--<span class="enable"><strong>Show All Context Screens</strong></span>-->
+						<!--</label>-->
+					<!--</div>-->
+				<!--</div>-->
+			<!--</div>-->
 		</div>
 
 	</div>


### PR DESCRIPTION
Now the user can select the context options from the extension itself. No need to open settings page every time to change options. This leads to better and easy use of the feature by a user. They can easily add or remove context options when they want to see them. 
Issue: #348

![image](https://user-images.githubusercontent.com/15799589/56642890-14b45180-6696-11e9-8491-d2dbfc468613.png)
![image](https://user-images.githubusercontent.com/15799589/56642897-1a119c00-6696-11e9-97fe-ac6400a06930.png)
