### PR TITLE
Refactoring global_url related code

### DIFF
--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -44,18 +44,6 @@ function get_clean_url(url) {
   return url
 }
 
-/* Common method used everywhere to retrieve cleaned up URL */
-function retrieve_url() {
-  var search_term = $('#search_input').val()
-  var url = ''
-  if (search_term === '') {
-    url = global_url
-  } else {
-    url = search_term
-  }
-  return url
-}
-
 function save_now() {
   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
     let url = get_clean_url(tabs[0].url)

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -85,9 +85,7 @@ function goBack () {
     $('#context-screen').off('click').css({ opacity: 0.5 })
   } else {
     if ($('#ctxbox').hasClass('flip-inside')) { $('#ctxbox').removeClass('flip-inside') }
-    $('#context-screen').off('click').css({ opacity: 1.0 }).on('click', function () {
-      chrome.runtime.sendMessage({ message: 'showall', url: get_clean_url() })
-    })
+    $('#context-screen').off('click').css({ opacity: 1.0 }).on('click', show_all_screens)
   }
 }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -150,7 +150,5 @@ if (typeof module !== 'undefined') {
     wmAvailabilityCheck: wmAvailabilityCheck,
     openByWindowSetting: openByWindowSetting,
     attachTooltip: attachTooltip,
-    // get_clean_url: get_clean_url,
-    // retrieve_url: retrieve_url
   }
 }


### PR DESCRIPTION
Previously, in `popup.js`, we are using a variable called `global_url` to store the current tab URL, however, the way we acquire the URL is by calling the `chrome.tabs.query` method, which is an asynchronous function. Hence we might fail to acquire the tab URL sometimes.

Now every time we need the tab URL, we just simply calling this method and do the following operations asynchronously.  