### PR TITLE
Bug fix

### DIFF
--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -84,7 +84,16 @@ function goBack () {
     if (!$('#ctxbox').hasClass('flip-inside')) { $('#ctxbox').addClass('flip-inside') }
     $('#context-screen').off('click').css({ opacity: 0.5 })
   } else {
-    if ($('#ctxbox').hasClass('flip-inside')) { $('#ctxbox').removeClass('flip-inside') }
+    if ($('#ctxbox').hasClass('flip-inside')) {
+      chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+        global_url = tabs[0].url
+        if (!isNotExcludedUrl(global_url)) {
+          $('#contextTip').text('URL not supported')
+        } else {
+          $('#ctxbox').removeClass('flip-inside') 
+        }
+      }) 
+    }
     $('#context-screen').off('click').css({ opacity: 1.0 }).on('click', function () {
       chrome.runtime.sendMessage({ message: 'showall', url: get_clean_url() })
     })


### PR DESCRIPTION
Now when it's a URL not supported site and you enable the context without reopening the extension page, the flipping effect will still be there and displaying "URL not supported"