### PR TITLE
Fix bug in welcome page not closing in firefox

### DIFF
--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -4,11 +4,15 @@ $(document).ready(function () {
   $('#accept').click(function () {
     chrome.storage.sync.set({ 'agreement': true }, function () {
       chrome.browserAction.setPopup({ popup: 'index.html' }, function () {
-        window.close()
+        chrome.tabs.getCurrent(function(tab) {
+          chrome.tabs.remove(tab.id, function() {})
+        })
       })
     })
   })
   $('#decline').click(function () {
-    window.close()
+    chrome.tabs.getCurrent(function(tab) {
+      chrome.tabs.remove(tab.id, function() {})
+    })
   })
 })


### PR DESCRIPTION
There was a bug in firefox, while the user is accepting "Internet Archive Terms of Use and Privacy Policy" or cancelling, the tab was not closing. In this PR, I have fixed that bug