### PR TITLE
Show related sites when data is there in Alexa Context Screen

### DIFF
--- a/context.html
+++ b/context.html
@@ -55,10 +55,12 @@
                     <div><b>Alexa Rank: <span class="color_code" id="alexa_rank"></span></b></div>
                     <div><b>Country: <span class="color_code" id="alexa_country"></span></b></div>
                     <br />
-                    <span class="glyphicon glyphicon-globe red" aria-hidden="true"></span>&nbsp;&nbsp;<b>Related sites:</b>
-                    <ul id="alexa_list" class="rl-list rl-link">
-                    </ul>
-                    <a id="alexa_page" href="#">Click to see more in alexa</a>
+                    <span class="related_sites">
+                        <span class="glyphicon glyphicon-globe red" aria-hidden="true"></span>&nbsp;&nbsp;<b>Related sites:</b>
+                        <ul id="alexa_list" class="rl-list rl-link"></ul>
+                    </span>
+                    
+                    <a id="alexa_page" target="_blank">Click to see more in alexa</a>
                 </div>
             </div>
         </div>

--- a/scripts/alexa.js
+++ b/scripts/alexa.js
@@ -34,9 +34,11 @@ function get_alexa () {
                     .text(title.length > TITLE_LEN ? title.substring(0, TITLE_LEN) + '...' : title)
           )
         )
-        $('#alexa_page').attr('href', 'https://archive.org/services/context/alexa?url=' + url)
       }
+    } else {
+      $('.related_sites').hide()
     }
+    $('#alexa_page').attr('href', 'https://archive.org/services/context/alexa?url=' + url)
     $('#loader_alexa').hide()
     $('#show_alexa_data').show()
   })


### PR DESCRIPTION
This PR includes fix to a bug in alexa context screen. Now Show Related data will show when data is there.