### PR TITLE
Shortened Count Badge to work on Firefox

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -12,12 +12,16 @@ let waybackCountCache = {}
  */
 function badgeCountText(count) {
   let text = ''
-  if (count < 10000) {
+  if (count < 1000) {
     text = count.toLocaleString()
+  } else if (count < 10000) {
+    text = (Math.round(count / 100) / 10.0).toLocaleString() + 'K'
   } else if (count < 1000000) {
-    text = Math.trunc(count / 1000) + 'K'
-  } else if (count >= 1000000) {
-    text = (Math.trunc(count / 100000) / 10.0) + 'M'
+    text = Math.round(count / 1000).toLocaleString() + 'K'
+  } else if (count < 10000000) {
+    text = (Math.round(count / 100000) / 10.0).toLocaleString() + 'M'
+  } else if (count >= 10000000) {
+    text = Math.round(count / 1000000).toLocaleString() + 'M'
   }
   return text
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -18,9 +18,7 @@ function badgeCountText(count) {
     text = (Math.round(count / 100) / 10.0).toLocaleString() + 'K'
   } else if (count < 1000000) {
     text = Math.round(count / 1000).toLocaleString() + 'K'
-  } else if (count < 10000000) {
-    text = (Math.round(count / 100000) / 10.0).toLocaleString() + 'M'
-  } else if (count >= 10000000) {
+  } else if (count >= 1000000) {
     text = Math.round(count / 1000000).toLocaleString() + 'M'
   }
   return text

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -57,7 +57,7 @@ describe('isNotExcludedUrl', () => {
   })
 })
 
-// on firefox, should fit ~4 full letters/digits without punctuation
+// on firefox, fits ~3.5 letters or digits
 describe('badgeCountText', () => {
   let test_cases = [
     { 'count': 1, 'result': '1' },
@@ -68,8 +68,8 @@ describe('badgeCountText', () => {
     { 'count': 12345, 'result': '12K' },
     { 'count': 123456, 'result': '123K' },
     { 'count': 1000000, 'result': '1M' },
-    { 'count': 1234567, 'result': '1.2M' },
-    { 'count': 8765432, 'result': '8.8M' },
+    { 'count': 1234567, 'result': '1M' },
+    { 'count': 8765432, 'result': '9M' },
     { 'count': 12000000, 'result': '12M' },
     { 'count': 12876543, 'result': '13M' },
     { 'count': 123000000, 'result': '123M' },

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -57,20 +57,23 @@ describe('isNotExcludedUrl', () => {
   })
 })
 
+// on firefox, should fit ~4 full letters/digits without punctuation
 describe('badgeCountText', () => {
   let test_cases = [
     { 'count': 1, 'result': '1' },
     { 'count': 12, 'result': '12' },
     { 'count': 123, 'result': '123' },
-    { 'count': 1234, 'result': '1,234' },
+    { 'count': 1234, 'result': '1.2K' },
+    { 'count': 1678, 'result': '1.7K' },
     { 'count': 12345, 'result': '12K' },
     { 'count': 123456, 'result': '123K' },
     { 'count': 1000000, 'result': '1M' },
     { 'count': 1234567, 'result': '1.2M' },
+    { 'count': 8765432, 'result': '8.8M' },
     { 'count': 12000000, 'result': '12M' },
-    { 'count': 12345678, 'result': '12.3M' },
+    { 'count': 12876543, 'result': '13M' },
     { 'count': 123000000, 'result': '123M' },
-    { 'count': 123456789, 'result': '123.4M' },
+    { 'count': 123456789, 'result': '123M' },
   ]
   test_cases.forEach(({ count, result }) => {
     it('should return ' + result + ' on ' + count, () => {


### PR DESCRIPTION
Please test on Firefox on a variety of websites.
Try to see if you can test against multiples of 10, such as: 100, 1K, 10K, 100K, 1M.
The goal is for the text to be fully visible, without any of it cut off.