### PR TITLE
Improve the content representation in Annotations Screen

### DIFF
--- a/css/context.css
+++ b/css/context.css
@@ -92,7 +92,6 @@ p {
     font-size: 20px;
     line-height: 1.42857143;
     color: #333;
-    word-break: break-all;
     word-wrap: break-word;
     background-color: #f5f5f5;
     border: 1px solid #ccc;

--- a/scripts/annotation.js
+++ b/scripts/annotation.js
@@ -71,7 +71,7 @@ function get_annotations (type = 'url') {
       let row = $('#row_contain-' + type)
       let item = row.clone()
       item.html(
-        $('<div>').addClass('col-sm-6 col-sm-offset-3 text-center')
+        $('<div>').addClass('text-center')
           .html(error_msg)
       )
       item.css('display', 'block')


### PR DESCRIPTION
This PR improves the content representation of the Annotations Context Page.

### Current Page

1. The text layout is distorted due to `word-break: break-all;`
The words are being broken at the right border of the box due to this property.
2. The "There are no annotations for the current URL." is at center now after removing some CSS classes.

![New Annotations Page](https://user-images.githubusercontent.com/42881874/82195880-8ea91f80-9916-11ea-9bea-71eb816159be.png)

### New Page
Removing `word-break` and some classes provide a fix.

![Capture](https://user-images.githubusercontent.com/42881874/82199935-fca41580-991b-11ea-96f9-381802938d10.PNG)


