### PR TITLE
Remove array where it contains a list of HTTP_CODE

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -29,7 +29,6 @@ var newshosts = [
   'www.vox.com',
   'www.washingtonpost.com'
 ]
-var HTTP_CODE = [404, 408, 410, 451, 500, 502, 503, 504, 509, 520, 521, 523, 524, 525, 526]
 
 function rewriteUserAgentHeader(e) {
   for (var header of e.requestHeaders) {
@@ -243,7 +242,7 @@ chrome.webRequest.onErrorOccurred.addListener(function (details) {
 chrome.webRequest.onCompleted.addListener(function (details) {
   function tabIsReady(isIncognito) {
     if (isIncognito === false && details.frameId === 0 &&
-      HTTP_CODE.includes(details.statusCode) && isNotExcludedUrl(details.url)) {
+      details.statusCode >= 400 && isNotExcludedUrl(details.url)) {
       globalStatusCode = details.statusCode
       wmAvailabilityCheck(details.url, function (wayback_url, url) {
         chrome.tabs.executeScript(details.tabId, {


### PR DESCRIPTION
In this PR I have removed the array of HTTP_CODE and used `details.statusCode >= 400` instead of looking up in the array. By doing this it also reduces the time complexity to constant time.

Fixes #519 