### PR TITLE
fixed error-404-popup bug

### DIFF
--- a/css/archive.css
+++ b/css/archive.css
@@ -34,6 +34,10 @@
     right: 10px;
 }
 
+#close {
+    cursor: pointer;
+}
+
 #logo {
     display: block;
     position: relative;

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -222,8 +222,8 @@ chrome.webRequest.onErrorOccurred.addListener(function (details) {
   if (['net::ERR_NAME_NOT_RESOLVED', 'net::ERR_NAME_RESOLUTION_FAILED',
     'net::ERR_CONNECTION_TIMED_OUT', 'net::ERR_NAME_NOT_RESOLVED'].indexOf(details.error) >= 0 &&
     details.tabId > 0) {
-    chrome.storage.sync.get(['not_found_popup'], function(event) {
-      if (event.not_found_popup === true) {
+    chrome.storage.sync.get(['not_found_popup','agreement'], function(event) {
+      if (event.not_found_popup === true && event.agreement === true) {
         wmAvailabilityCheck(details.url, function (wayback_url, url) {
           chrome.tabs.sendMessage(details.tabId, {
             type: 'SHOW_BANNER',
@@ -273,8 +273,8 @@ chrome.webRequest.onCompleted.addListener(function (details) {
       var tabsArr = tabs.map(tab => tab.id)
       if (tabsArr.indexOf(details.tabId) >= 0) {
         chrome.tabs.get(details.tabId, function (tab) {
-          chrome.storage.sync.get(['not_found_popup'], function(event) {
-            if (event.not_found_popup === true) {
+          chrome.storage.sync.get(['not_found_popup','agreement'], function(event) {
+            if (event.not_found_popup === true && event.agreement === true) {
               tabIsReady(tab.incognito)
             }
           })


### PR DESCRIPTION
This PR fixes the following issues

1. This feature works even without clicking on the "Accept and Enable" button in the Welcome 
     page. This should not happen

2. We can add `cursor: pointer` in #close { } in archive.css.

In developer edition of firefox I am testing this, I got to know why it is happening, but still thinking of a solution.