### PR TITLE
URL mismatch 

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -16,7 +16,7 @@ let toolbarIconState = {}
 let tabIdPromise
 var WB_API_URL = 'https://archive.org/wayback/available'
 var newshosts = [
-  'www.apnews.com',
+  'apnews.com',
   'www.factcheck.org',
   'www.forbes.com',
   'www.huffpost.com',


### PR DESCRIPTION


This PR solves the issues in displaying Related TV Clips. 

1. There was a URL mismatch in `background.js`: https://apnews.com isn't the same as https://www.apnews.com since we are matching strings.