### PR TITLE
Fix Saving Messages

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -525,9 +525,9 @@ function setToolbarIcon(name) {
 }
 
 function setToolbarState(tabId, name) {
-  toolbarIconState[tabId] = name
   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
     if (tabs[0].id === tabId) {
+      toolbarIconState[tabId] = name
       setToolbarIcon(name)
     }
   })

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -512,21 +512,25 @@ function updateWaybackCountBadge(tabId, url) {
  * Name string is based on PNG image filename in images/toolbar/
  * @param name {string} = one of 'archive', 'check', 'R', or 'S'
  */
-function setToolbarIcon(name) {
+function setToolbarIcon(tabId, name) {
   const path = 'images/toolbar/toolbar-icon-'
-  let n = ((name !== 'R') && (name !== 'S') && (name !== 'check')) ? 'archive' : name
-  let details = {
-    '16': (path + n + '16.png'),
-    '24': (path + n + '24.png'),
-    '32': (path + n + '32.png'),
-    '64': (path + n + '64.png')
-  }
-  chrome.browserAction.setIcon({ path: details })
+  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+    if (tabs[0].id === tabId) {
+      let n = ((name !== 'R') && (name !== 'S') && (name !== 'check')) ? 'archive' : name
+      let details = {
+        '16': (path + n + '16.png'),
+        '24': (path + n + '24.png'),
+        '32': (path + n + '32.png'),
+        '64': (path + n + '64.png')
+      }
+      chrome.browserAction.setIcon({ path: details })
+    }
+  })
 }
 
 function setToolbarState(tabId, name) {
   toolbarIconState[tabId] = name
-  setToolbarIcon(name)
+  setToolbarIcon(tabId, name)
 }
 
 function getToolbarState(tabId) {
@@ -537,11 +541,11 @@ function clearToolbarState(tabId) {
   if (toolbarIconState[tabId]) {
     delete toolbarIconState[tabId]
   }
-  setToolbarIcon('archive')
+  setToolbarIcon(tabId, 'archive')
 }
 
 function updateToolbarIcon(tabId) {
-  setToolbarIcon(getToolbarState(tabId))
+  setToolbarIcon(tabId, getToolbarState(tabId))
 }
 
 // Right-click context menu "Wayback Machine" inside the page.

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -512,25 +512,25 @@ function updateWaybackCountBadge(tabId, url) {
  * Name string is based on PNG image filename in images/toolbar/
  * @param name {string} = one of 'archive', 'check', 'R', or 'S'
  */
-function setToolbarIcon(tabId, name) {
+function setToolbarIcon(name) {
   const path = 'images/toolbar/toolbar-icon-'
-  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-    if (tabs[0].id === tabId) {
-      let n = ((name !== 'R') && (name !== 'S') && (name !== 'check')) ? 'archive' : name
-      let details = {
-        '16': (path + n + '16.png'),
-        '24': (path + n + '24.png'),
-        '32': (path + n + '32.png'),
-        '64': (path + n + '64.png')
-      }
-      chrome.browserAction.setIcon({ path: details })
-    }
-  })
+  let n = ((name !== 'R') && (name !== 'S') && (name !== 'check')) ? 'archive' : name
+  let details = {
+    '16': (path + n + '16.png'),
+    '24': (path + n + '24.png'),
+    '32': (path + n + '32.png'),
+    '64': (path + n + '64.png')
+  }
+  chrome.browserAction.setIcon({ path: details })
 }
 
 function setToolbarState(tabId, name) {
   toolbarIconState[tabId] = name
-  setToolbarIcon(tabId, name)
+  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+    if (tabs[0].id === tabId) {
+      setToolbarIcon(name)
+    }
+  })
 }
 
 function getToolbarState(tabId) {
@@ -541,11 +541,11 @@ function clearToolbarState(tabId) {
   if (toolbarIconState[tabId]) {
     delete toolbarIconState[tabId]
   }
-  setToolbarIcon(tabId, 'archive')
+  setToolbarIcon('archive')
 }
 
 function updateToolbarIcon(tabId) {
-  setToolbarIcon(tabId, getToolbarState(tabId))
+  setToolbarIcon(getToolbarState(tabId))
 }
 
 // Right-click context menu "Wayback Machine" inside the page.

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -525,12 +525,8 @@ function setToolbarIcon(name) {
 }
 
 function setToolbarState(tabId, name) {
-  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-    if (tabs[0].id === tabId) {
-      toolbarIconState[tabId] = name
-      setToolbarIcon(name)
-    }
-  })
+  toolbarIconState[tabId] = name
+  updateToolbarIcon(tabId)
 }
 
 function getToolbarState(tabId) {
@@ -541,11 +537,17 @@ function clearToolbarState(tabId) {
   if (toolbarIconState[tabId]) {
     delete toolbarIconState[tabId]
   }
-  setToolbarIcon('archive')
+  updateToolbarIcon(tabId)
 }
 
+// Only update the toolbar icon if tabId is the currently active tab
 function updateToolbarIcon(tabId) {
-  setToolbarIcon(getToolbarState(tabId))
+  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+    if (tabs[0].id === tabId) {
+      let name = toolbarIconState[tabId]
+      setToolbarIcon(name ? name : 'archive')
+    }
+  })
 }
 
 // Right-click context menu "Wayback Machine" inside the page.

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -110,7 +110,8 @@ async function validate_spn(tabId, job_id, silent = false) {
   while ((status === 'start') || (status === 'pending')) {
     // update UI
     chrome.runtime.sendMessage({
-      message: 'save_start'
+      message: 'save_start',
+      tabId: tabId
     })
     if (status === 'pending') {
       setToolbarState(tabId, 'S')
@@ -144,7 +145,8 @@ async function validate_spn(tabId, job_id, silent = false) {
     setToolbarState(tabId, 'check')
     chrome.runtime.sendMessage({
       message: 'save_success',
-      time: 'Last saved: ' + getLastSaveTime(vdata.timestamp)
+      time: 'Last saved: ' + getLastSaveTime(vdata.timestamp),
+      tabId: tabId
     })
     if (!silent) {
       let msg = 'Successfully saved! Click to view snapshot.'
@@ -288,6 +290,7 @@ function getLastSaveTime(timestamp) {
 
 chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
   if (message.message === 'openurl') {
+    let tabId = message.tabId
     var page_url = message.page_url
     var wayback_url = message.wayback_url
     var url = page_url.replace(/https:\/\/web\.archive\.org\/web\/(.+?)\//g, '')
@@ -297,7 +300,7 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
         URLopener(open_url, url, true)
       } else {
         let options = (message.options !== null) ? message.options : []
-        savePageNow(null, page_url, false, options)
+        savePageNow(tabId, page_url, false, options)
         return true
       }
     }

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -67,7 +67,8 @@ function save_now() {
       wayback_url: hostURL + 'save/',
       page_url: url,
       options: options,
-      method: 'save'
+      method: 'save',
+      tabId: tabs[0].id
     })
   })
 }
@@ -464,23 +465,27 @@ chrome.storage.sync.get(['show_context'], function(event) { $(`input[name=tw][va
 
 chrome.runtime.onMessage.addListener(
   function(message) {
-    if (message.message === 'save_success') {
-      $('#save_now').text('Save successful')
-      $('#last_save').text(message.time)
-      $('#savebox').addClass('flip-inside')
-    }
-    if (message.message === 'save_start') {
-      $('#save_now').text('Saving Snapshot...')
-    }
-    // if(message.message === "save_error"){
-    //   $('#save_now').text('Save Failed')
-    //   $('#last_save').text(message.error)
-    //   if(message.error === "You need to be logged in to use Save Page Now."){
-    //     $('#savebtn').off('click').click(function(){
-    //       openByWindowSetting('https://archive.org/account/login');
-    //     })
-    //   }
-    // }
+    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+      if (tabs[0].id === message.tabId) {
+        if (message.message === 'save_success') {
+          $('#save_now').text('Save successful')
+          $('#last_save').text(message.time)
+          $('#savebox').addClass('flip-inside')
+        }
+        if (message.message === 'save_start') {
+          $('#save_now').text('Saving Snapshot...')
+        }
+        // if(message.message === "save_error"){
+        //   $('#save_now').text('Save Failed')
+        //   $('#last_save').text(message.error)
+        //   if(message.error === "You need to be logged in to use Save Page Now."){
+        //     $('#savebtn').off('click').click(function(){
+        //       openByWindowSetting('https://archive.org/account/login');
+        //     })
+        //   }
+        // }
+      }
+    })
   }
 )
 


### PR DESCRIPTION
This PR ensures the following:
1. "Saving Snapshot..." and "Save Successful" messages can only be seen on the tab which is being/has been saved.
2. The toolbar icons ('S' and 'check') can only be seen on the tab which is being/has been saved.

Issue #530 