### PR TITLE
Set Tabs to be Opened in Context Page

### DIFF
--- a/scripts/context.js
+++ b/scripts/context.js
@@ -56,7 +56,7 @@ function singlePageView() {
   // Check settings for features
   let features = ['alexa', 'domaintools', 'wbmsummary', 'annotations', 'tagcloud']
   chrome.storage.sync.get(features, function (event) {
-    let firstFeature = null
+    let clickFeature = null
     for (let i = 0; i < features.length; i++) {
       let feature = features[i]
       let featureId = '#' + feature.charAt(0).toUpperCase() + feature.substring(1)
@@ -66,24 +66,6 @@ function singlePageView() {
       if (!event[feature]) {
         $(featureId).hide()
         $(featureTabId).hide()
-
-        //Show first tab if the last clicked tab is hidden
-        chrome.storage.sync.get(['selectedFeature'], function(result) {
-          let openedFeature = result.selectedFeature
-          if (openedFeature === featureTabId) {
-            for (let i = 0; i < features.length; i++) {
-              let feature = features[i]
-              let featureId = '#' + feature.charAt(0).toUpperCase() + feature.substring(1)
-              let featureTabId = featureId + '_tab'
-              if (event[feature]) {
-                if (!firstFeature) {
-                  firstFeature = featureTabId
-                  $(firstFeature).click()
-                }
-              }
-            }
-          }
-        })
       } else {
         contexts_dic[feature]()
         $(featureTabId).click(function(event) {
@@ -91,22 +73,27 @@ function singlePageView() {
           chrome.storage.sync.set({selectedFeature: selectedFeature}, function() {
           })
         })
-          
-        //Show the last clicked tab
         chrome.storage.sync.get(['selectedFeature'], function(result) {
           let openedFeature = result.selectedFeature
-          if (openedFeature) {
-            $(openedFeature).click()
-          } else {
-              
-            //Show first tab if user is accesing Contexts Page for the first time
-            if (!firstFeature) {
-              firstFeature = featureTabId
-              $(firstFeature).click()
-            }
+          //Get first tab
+          if (!clickFeature) {
+            clickFeature = featureTabId
           }
-        })
-      }        
+          if (openedFeature) {
+            //Open the first tab if last selected tab is hidden now
+            if (openedFeature !== featureTabId) {
+              $(clickFeature).click()
+            } else {
+              //Open the last selected tab
+              clickFeature = openedFeature
+              $(clickFeature).click()
+            }
+          } else {
+            //Open first tab if user is accesing Contexts Page for the first time
+            $(clickFeature).click()
+          }
+        })    
+      }
     }
   }) 
 }

--- a/scripts/context.js
+++ b/scripts/context.js
@@ -56,25 +56,25 @@ function singlePageView() {
   // Check settings for features
   let features = ['alexa', 'domaintools', 'wbmsummary', 'annotations', 'tagcloud']
   chrome.storage.sync.get(features, function (event) {
-    let clickFeature = null
-    for (let i = 0; i < features.length; i++) {
-      let feature = features[i]
-      let featureId = '#' + feature.charAt(0).toUpperCase() + feature.substring(1)
-      let featureTabId = featureId + '_tab'
+    chrome.storage.sync.get(['selectedFeature'], function(result) {
+      var openedFeature = result.selectedFeature
+      let clickFeature = null
+      for (let i = 0; i < features.length; i++) {
+        let feature = features[i]
+        let featureId = '#' + feature.charAt(0).toUpperCase() + feature.substring(1)
+        let featureTabId = featureId + '_tab'
 
-      // Hide features that weren't selected
-      if (!event[feature]) {
-        $(featureId).hide()
-        $(featureTabId).hide()
-      } else {
-        contexts_dic[feature]()
-        $(featureTabId).click(function(event) {
-          let selectedFeature = openContextFeature(event, featureId) + '_tab'
-          chrome.storage.sync.set({selectedFeature: selectedFeature}, function() {
+        // Hide features that weren't selected
+        if (!event[feature]) {
+          $(featureId).hide()
+          $(featureTabId).hide()
+        } else {
+          contexts_dic[feature]()
+          $(featureTabId).click(function(event) {
+            let selectedFeature = openContextFeature(event, featureId) + '_tab'
+            chrome.storage.sync.set({selectedFeature: selectedFeature}, function() {
+            })
           })
-        })
-        chrome.storage.sync.get(['selectedFeature'], function(result) {
-          let openedFeature = result.selectedFeature
           //Get first tab
           if (!clickFeature) {
             clickFeature = featureTabId
@@ -92,9 +92,9 @@ function singlePageView() {
             //Open first tab if user is accesing Contexts Page for the first time
             $(clickFeature).click()
           }
-        })    
+        }
       }
-    }
+    })
   }) 
 }
 

--- a/scripts/context.js
+++ b/scripts/context.js
@@ -56,6 +56,7 @@ function singlePageView() {
   // Check settings for features
   let features = ['alexa', 'domaintools', 'wbmsummary', 'annotations', 'tagcloud']
   chrome.storage.sync.get(features, function (event) {
+    let firstFeature = null
     for (let i = 0; i < features.length; i++) {
       let feature = features[i]
       let featureId = '#' + feature.charAt(0).toUpperCase() + feature.substring(1)
@@ -65,6 +66,24 @@ function singlePageView() {
       if (!event[feature]) {
         $(featureId).hide()
         $(featureTabId).hide()
+
+        //Show first tab if the last clicked tab is hidden
+        chrome.storage.sync.get(['selectedFeature'], function(result) {
+          let openedFeature = result.selectedFeature
+          if (openedFeature === featureTabId) {
+            for (let i = 0; i < features.length; i++) {
+              let feature = features[i]
+              let featureId = '#' + feature.charAt(0).toUpperCase() + feature.substring(1)
+              let featureTabId = featureId + '_tab'
+              if (event[feature]) {
+                if (!firstFeature) {
+                  firstFeature = featureTabId
+                  $(firstFeature).click()
+                }
+              }
+            }
+          }
+        })
       } else {
         contexts_dic[feature]()
         $(featureTabId).click(function(event) {
@@ -72,18 +91,24 @@ function singlePageView() {
           chrome.storage.sync.set({selectedFeature: selectedFeature}, function() {
           })
         })
-        //Set the default feature to be opened
+          
+        //Show the last clicked tab
         chrome.storage.sync.get(['selectedFeature'], function(result) {
           let openedFeature = result.selectedFeature
           if (openedFeature) {
             $(openedFeature).click()
           } else {
-            $('#Alexa_tab').click()
+              
+            //Show first tab if user is accesing Contexts Page for the first time
+            if (!firstFeature) {
+              firstFeature = featureTabId
+              $(firstFeature).click()
+            }
           }
         })
-      }
+      }        
     }
-  })
+  }) 
 }
 
 window.onload = singlePageView


### PR DESCRIPTION
This PR provides the following fixes:

1. Open the first tab if the user is accessing the Context Page for the first time.
2. Open the previously opened tab when the user switches between webpages with **"Auto-update Contexts"** option enabled.
3. Open the first tab if the previously opened tab is not selected in the Contexts menu.
4. Open the previously opened tab if it's option is selected in the Contexts menu.