### PR TITLE
Fix 'Show Contexts' button bugs

### DIFF
--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -393,10 +393,27 @@ function show_wikibooks() {
 function noContextTip() {
   chrome.storage.sync.get(['alexa', 'domaintools', 'tweets', 'wbmsummary', 'annotations', 'tagcloud'], function (event) {
     // If none of the context is selected, grey out the button and adding tip when the user hovers
-    for (const context in event) { if (event[context]) { return $('#context-screen').click(show_all_screens) } }
-    if (!$('#ctxbox').hasClass('flip-inside')) { $('#ctxbox').addClass('flip-inside') }
+    for (const context in event) { 
+      if (event[context]) { 
+        $('#contextBtn').removeAttr('disabled')
+        return $('#contextBtn').click(show_all_screens) 
+      }
+    }
+    if (!$('#ctxbox').hasClass('flip-inside')) {
+      $('#ctxbox').addClass('flip-inside')
+      $('#contextBtn').attr('disabled', true)
+    }
     /* $('#context-screen').css({ opacity: 0.5 }) */
   })
+}
+
+function openContextMenu () {
+  $('#popup-page').hide()
+  $('#setting-page').show()
+  $('#general-panel').hide()
+  $('#context-panel').show()
+  if (!$('#context-btn').hasClass('selected')) { $('#context-btn').addClass('selected') }
+  if ($('#general-btn').hasClass('selected')) { $('#general-btn').removeClass('selected') }
 }
 
 function checkExcluded() {
@@ -404,12 +421,13 @@ function checkExcluded() {
     let url = tabs[0].url
     if (isNotExcludedUrl(url)) {
       last_save()
+      $('#contextTip').click(openContextMenu)
     } else {
-      const idList = ['savebox', 'mapbox', 'twitterbox']
+      const idList = ['savebox', 'mapbox', 'twitterbox', 'ctxbox']
       idList.forEach((id) => { $(`#${id}`).addClass('flip-inside') })
+      $('#contextBtn').attr('disabled', true)
       $('#last_save').text('URL not supported')
       $('#contextTip').text('URL not supported')
-      $('#ctxbox').addClass('flip-inside')
       $('#url-not-supported-message').text('URL not supported')
     }
   })

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -396,7 +396,7 @@ function noContextTip() {
     for (const context in event) { 
       if (event[context]) { 
         $('#contextBtn').removeAttr('disabled')
-        return $('#contextBtn').click(show_all_screens) 
+        return $('#contextBtn').click(show_all_screens)
       }
     }
     if (!$('#ctxbox').hasClass('flip-inside')) {

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -109,39 +109,32 @@ function noneSelected () {
   return true
 }
 
-function openContextMenu () {
-  $('#popup-page').hide()
-  $('#setting-page').show()
-  $('#general-panel').hide()
-  $('#context-panel').show()
-  if (!$('#context-btn').hasClass('selected')) { $('#context-btn').addClass('selected') }
-  if ($('#general-btn').hasClass('selected')) { $('#general-btn').removeClass('selected') }
-}
-
 function goBack () {
   $('#setting-page').hide()
   $('#popup-page').show()
-  // checking contexts selection status
-  if (noneSelected()) {
-    if (!$('#ctxbox').hasClass('flip-inside')) { $('#ctxbox').addClass('flip-inside') }
-    /* $('#context-screen').off('click').css({ opacity: 0.5 }) */
-    $('#contextBtn').off('click')
-    $('#contextBtn').attr('disabled', true)
-    $('#contextTip').click(openContextMenu)
-  } else {
-    if ($('#ctxbox').hasClass('flip-inside')) {
-      chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+    // checking contexts selection status
+    if (noneSelected()) {
+      if (!$('#ctxbox').hasClass('flip-inside')) { $('#ctxbox').addClass('flip-inside') }
+      /* $('#context-screen').off('click').css({ opacity: 0.5 }) */
+      $('#contextBtn').off('click')
+      $('#contextBtn').attr('disabled', true)
+      if (isNotExcludedUrl(tabs[0].url)) {
+        $('#contextTip').click(openContextMenu)
+      }
+    } else {
+      if ($('#ctxbox').hasClass('flip-inside')) {
         if (!isNotExcludedUrl(tabs[0].url)) {
           $('#contextTip').text('URL not supported')
         } else {
           $('#ctxbox').removeClass('flip-inside')
         }
-      })
+      }
+      /* $('#context-screen').off('click').css({ opacity: 1.0 }).on('click', show_all_screens) */
+      $('#contextBtn').off('click').on('click', show_all_screens) /* TODO: check this */
+      $('#contextBtn').removeAttr('disabled')
     }
-    /* $('#context-screen').off('click').css({ opacity: 1.0 }).on('click', show_all_screens) */
-    $('#context-screen').off('click').on('click', show_all_screens) /* TODO: check this */
-    $('#contextBtn').removeAttr('disabled')
-  }
+  })
 }
 
 function switchSetting() {

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -131,7 +131,7 @@ function goBack () {
         }
       }
       /* $('#context-screen').off('click').css({ opacity: 1.0 }).on('click', show_all_screens) */
-      $('#contextBtn').off('click').on('click', show_all_screens) /* TODO: check this */
+      $('#contextBtn').off('click').on('click', show_all_screens)
       $('#contextBtn').removeAttr('disabled')
     }
   })

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -109,6 +109,15 @@ function noneSelected () {
   return true
 }
 
+function openContextMenu () {
+  $('#popup-page').hide()
+  $('#setting-page').show()
+  $('#general-panel').hide()
+  $('#context-panel').show()
+  if (!$('#context-btn').hasClass('selected')) { $('#context-btn').addClass('selected') }
+  if ($('#general-btn').hasClass('selected')) { $('#general-btn').removeClass('selected') }
+}
+
 function goBack () {
   $('#setting-page').hide()
   $('#popup-page').show()
@@ -116,8 +125,9 @@ function goBack () {
   if (noneSelected()) {
     if (!$('#ctxbox').hasClass('flip-inside')) { $('#ctxbox').addClass('flip-inside') }
     /* $('#context-screen').off('click').css({ opacity: 0.5 }) */
-    $('#context-screen').off('click')
+    $('#contextBtn').off('click')
     $('#contextBtn').attr('disabled', true)
+    $('#contextTip').click(openContextMenu)
   } else {
     if ($('#ctxbox').hasClass('flip-inside')) {
       chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {


### PR DESCRIPTION
This PR provides the following fixes:
1. Clicking 'Enable in Settings' opens Context settings.
2. Dimming the 'Show Contexts' button when disabled.