### PR TITLE
Show error message on empty Context screen

### DIFF
--- a/context.html
+++ b/context.html
@@ -20,7 +20,7 @@
 </head>
 <body>
     <!-- Error message -->
-    <div class="container" id="error-message">
+    <div class="container display-none" id="error-message">
         <div>
             <div class="col-sm-12 text-center">
                 <h2>Error</h2>

--- a/context.html
+++ b/context.html
@@ -27,7 +27,7 @@
             </div>
             <div class="col-sm-6">
                 <div class="pre">
-                    <div class="color_code text-center"><h4>No Context Selected</h4></div>
+                    <div class="text-center"><h4 class="color_code">No Context Selected</h4></div>
                     <div class="error">
                         <span>Looks like you didn't make any selection in the <b>Contexts</b> menu. Please follow the steps given below:</span>
                         <ul>

--- a/context.html
+++ b/context.html
@@ -20,7 +20,7 @@
 </head>
 <body>
     <!-- Error message -->
-    <div class="container display-none" id="error-message">
+    <div class="container" id="error-message">
         <div>
             <div class="col-sm-12 text-center">
                 <h2>Error</h2>

--- a/context.html
+++ b/context.html
@@ -19,6 +19,29 @@
     <title>Show Contexts</title>
 </head>
 <body>
+    <!-- Error message -->
+    <div class="container" id="error-message">
+        <div>
+            <div class="col-sm-12 text-center">
+                <h2>Error</h2>
+            </div>
+            <div class="col-sm-6">
+                <div class="pre">
+                    <div class="color_code text-center"><h4>No Context Selected</h4></div>
+                    <div class="error">
+                        <span>Looks like you didn't make any selection in the <b>Contexts</b> menu. Please follow the steps given below:</span>
+                        <ul>
+                            <li>Go to the <b>Settings</b> menu in the extension</li>
+                            <li>Switch to <b>Contexts</b> menu</li>
+                            <li>Select features to be displayed on this page</li>
+                            <li>Refresh this page</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
   <!-- Tab links -->
     <div class="container-fluid">
         <div class="row tab">

--- a/css/context.css
+++ b/css/context.css
@@ -158,7 +158,7 @@ p {
     padding: 6px 12px;
 }
 
-#row_contain-url, #row_contain-domain {
+#row_contain-url, #row_contain-domain, .display-none {
     display: none;
 }
 

--- a/css/context.css
+++ b/css/context.css
@@ -158,7 +158,7 @@ p {
     padding: 6px 12px;
 }
 
-#row_contain-url, #row_contain-domain, .display-none {
+#row_contain-url, #row_contain-domain, #error-message {
     display: none;
 }
 

--- a/css/context.css
+++ b/css/context.css
@@ -204,7 +204,7 @@ p {
         border: 1px solid #555;
     }
 
-    a {
+    a, .error b {
         color: #d66;
     }
     a:hover {

--- a/scripts/context.js
+++ b/scripts/context.js
@@ -98,7 +98,7 @@ function singlePageView() {
       }
       //Show error message if no context is selected
       if (countFeature <= 0) {
-        $('#error-message').removeClass('display-none')
+        $('#error-message').show()
       }
     })
   }) 

--- a/scripts/context.js
+++ b/scripts/context.js
@@ -59,6 +59,7 @@ function singlePageView() {
     chrome.storage.sync.get(['selectedFeature'], function(result) {
       var openedFeature = result.selectedFeature
       let clickFeature = null
+      let countFeature = 0
       for (let i = 0; i < features.length; i++) {
         let feature = features[i]
         let featureId = '#' + feature.charAt(0).toUpperCase() + feature.substring(1)
@@ -69,6 +70,7 @@ function singlePageView() {
           $(featureId).hide()
           $(featureTabId).hide()
         } else {
+          countFeature++
           contexts_dic[feature]()
           $(featureTabId).click(function(event) {
             let selectedFeature = openContextFeature(event, featureId) + '_tab'
@@ -93,6 +95,10 @@ function singlePageView() {
             $(clickFeature).click()
           }
         }
+      }
+      //Hide error message if a context is selected
+      if (countFeature > 0) {
+        $('#error-message').hide()
       }
     })
   }) 

--- a/scripts/context.js
+++ b/scripts/context.js
@@ -96,9 +96,9 @@ function singlePageView() {
           }
         }
       }
-      //Hide error message if a context is selected
-      if (countFeature > 0) {
-        $('#error-message').hide()
+      //Show error message if no context is selected
+      if (countFeature <= 0) {
+        $('#error-message').removeClass('display-none')
       }
     })
   }) 


### PR DESCRIPTION
This PR shows an error message to the user on the 'Context' page if there are no contexts selected.