### PR TITLE
Toolbar icons now work with multiple concurrent states.

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -381,7 +381,11 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     })
   } else if (message.message === 'getToolbarState') {
     // retrieve the toolbar state set
-    sendResponse({ state: getToolbarState(message.tabId) })
+    //sendResponse({ state: getToolbarState(message.tabId) })
+    let state = getToolbarState(message.tabId)
+    console.log('getToolbarState: ', state) // DEBUG
+    // FIXME: sending state won't work unless it's JSON compatible (which Set() isn't)
+    sendResponse({ stateArray: Array.from(state) })
   } else if (message.message === 'clearCountBadge') {
     // wayback count settings unchecked
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
@@ -576,20 +580,22 @@ function setToolbarIcon(name) {
   chrome.browserAction.setIcon({ path: details })
 }
 
-// Add state to the state set for given tabId.
+// Add state to the state set for given tabId, and update toolbar.
 // state is 'S', 'R', or 'check'
 function addToolbarState(tabId, state) {
   if (!gToolbarStates[tabId]) {
     gToolbarStates[tabId] = new Set()
   }
   gToolbarStates[tabId].add(state)
+  updateToolbar(tabId)
 }
 
-// Remove state from the state set for given tabId.
+// Remove state from the state set for given tabId, and update toolbar.
 function removeToolbarState(tabId, state) {
   if (gToolbarStates[tabId]) {
     gToolbarStates[tabId].delete(state)
   }
+  updateToolbar(tabId)
 }
 
 // Returns a Set of toolbar states, or an empty set.
@@ -598,7 +604,7 @@ function getToolbarState(tabId) {
 }
 
 // Clears state for given tabId and update toolbar icon.
-function clearToolbar(tabId) {
+function clearToolbarState(tabId) {
   if (gToolbarStates[tabId]) {
     gToolbarStates[tabId].clear()
     delete gToolbarStates[tabId]

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -12,7 +12,6 @@ var manifest = chrome.runtime.getManifest()
 var VERSION = manifest.version
 // Used to store the statuscode of the if it is a httpFailCodes
 var globalStatusCode = ''
-//let toolbarIconState = {} // REMOVE
 let gToolbarStates = {}
 let waybackCountCache = {}
 let tabIdPromise
@@ -381,10 +380,7 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     })
   } else if (message.message === 'getToolbarState') {
     // retrieve the toolbar state set
-    //sendResponse({ state: getToolbarState(message.tabId) })
     let state = getToolbarState(message.tabId)
-    console.log('getToolbarState: ', state) // DEBUG
-    // FIXME: sending state won't work unless it's JSON compatible (which Set() isn't)
     sendResponse({ stateArray: Array.from(state) })
   } else if (message.message === 'clearCountBadge') {
     // wayback count settings unchecked
@@ -634,35 +630,6 @@ function updateToolbar(tabId) {
     }
   })
 }
-
-// REMOVE
-/*
-function setToolbarState(tabId, name) {
-  toolbarIconState[tabId] = name
-  updateToolbarIcon(tabId)
-}
-
-function getToolbarState(tabId) {
-  return toolbarIconState[tabId]
-}
-
-function clearToolbarState(tabId) {
-  if (toolbarIconState[tabId]) {
-    delete toolbarIconState[tabId]
-  }
-  updateToolbarIcon(tabId)
-}
-
-// Only update the toolbar icon if tabId is the currently active tab
-function updateToolbarIcon(tabId) {
-  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-    if (tabs[0].id === tabId) {
-      let name = toolbarIconState[tabId]
-      setToolbarIcon(name || 'archive')
-    }
-  })
-}
-*/
 
 /* * * Right-click Menu * * */
 

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -424,7 +424,7 @@ chrome.tabs.onUpdated.addListener(function (tabId, info, tab) {
     })
   } else if (info.status === 'loading') {
     var received_url = tab.url
-    removeToolbarState(tab.id, 'R')
+    clearToolbarState(tab.id)
     if (isNotExcludedUrl(received_url) && !(received_url.includes('alexa.com') || received_url.includes('whois.com') || received_url.includes('twitter.com') || received_url.includes('oauth'))) {
       let contextUrl = received_url
       received_url = received_url.replace(/^https?:\/\//, '')

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -376,7 +376,6 @@ function show_wikibooks() {
     if (url.match(/^https?:\/\/[\w\.]*wikipedia.org/)) {
       chrome.runtime.sendMessage({ message: 'getToolbarState', tabId: tabId }, function(result) {
         let state = (result.stateArray) ? new Set(result.stateArray) : new Set()
-        console.log('show_wikibooks() state: ', state) // DEBUG
         if (state.has('R')) {
           // show wikipedia books button
           $('#wikibooks_tr').show().click(function () {

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -51,7 +51,7 @@ function get_clean_url(url) {
 
 function save_now() {
   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-    let url = get_clean_url(tabs[0].url)
+    let url = tabs[0].url
     let options = ['capture_all']
     if ($('#chk-outlinks').prop('checked') === true) {
       options.push('capture_outlinks')
@@ -85,7 +85,7 @@ function last_save() {
     } else {
       $('#save_now').removeAttr('disabled')
       chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-        let url = get_clean_url(tabs[0].url)
+        let url = tabs[0].url
         chrome.runtime.sendMessage({
           message: 'getLastSaveTime',
           page_url: url

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -314,7 +314,7 @@ function borrow_books() {
     const tabId = tabs[0].id
     if (url.includes('www.amazon') && url.includes('/dp/')) {
       chrome.runtime.sendMessage({ message: 'getToolbarState', tabId: tabId }, function(result) {
-        if (result.state === 'R') {
+        if (result.state && result.state.has('R')) {
           $('#borrow_books_tr').css({ 'display': 'block' })
           chrome.storage.sync.get(['tab_url', 'detail_url', 'show_context'], function (res) {
             const stored_url = res.tab_url
@@ -356,7 +356,7 @@ function show_news() {
       const option = event.show_context
       if (set_of_sites.has(news_host)) {
         chrome.runtime.sendMessage({ message: 'getToolbarState', tabId: tabId }, function(result) {
-          if (result.state === 'R') {
+          if (result.state && result.state.has('R')) {
             $('#news_recommend_tr').show().click(() => {
               const URL = chrome.runtime.getURL('recommendations.html') + '?url=' + url
               openByWindowSetting(URL, option)
@@ -373,7 +373,7 @@ function show_wikibooks() {
     const tabId = tabs[0].id
     if (url.match(/^https?:\/\/[\w\.]*wikipedia.org/)) {
       chrome.runtime.sendMessage({ message: 'getToolbarState', tabId: tabId }, function(result) {
-        if (result.state === 'R') {
+        if (result.state && result.state.has('R')) {
           // show wikipedia books button
           $('#wikibooks_tr').show().click(function () {
             const URL = chrome.runtime.getURL('booklist.html') + '?url=' + url

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -314,7 +314,8 @@ function borrow_books() {
     const tabId = tabs[0].id
     if (url.includes('www.amazon') && url.includes('/dp/')) {
       chrome.runtime.sendMessage({ message: 'getToolbarState', tabId: tabId }, function(result) {
-        if (result.state && result.state.has('R')) {
+        let state = (result.stateArray) ? new Set(result.stateArray) : new Set()
+        if (state.has('R')) {
           $('#borrow_books_tr').css({ 'display': 'block' })
           chrome.storage.sync.get(['tab_url', 'detail_url', 'show_context'], function (res) {
             const stored_url = res.tab_url
@@ -356,7 +357,8 @@ function show_news() {
       const option = event.show_context
       if (set_of_sites.has(news_host)) {
         chrome.runtime.sendMessage({ message: 'getToolbarState', tabId: tabId }, function(result) {
-          if (result.state && result.state.has('R')) {
+          let state = (result.stateArray) ? new Set(result.stateArray) : new Set()
+          if (state.has('R')) {
             $('#news_recommend_tr').show().click(() => {
               const URL = chrome.runtime.getURL('recommendations.html') + '?url=' + url
               openByWindowSetting(URL, option)
@@ -373,7 +375,9 @@ function show_wikibooks() {
     const tabId = tabs[0].id
     if (url.match(/^https?:\/\/[\w\.]*wikipedia.org/)) {
       chrome.runtime.sendMessage({ message: 'getToolbarState', tabId: tabId }, function(result) {
-        if (result.state && result.state.has('R')) {
+        let state = (result.stateArray) ? new Set(result.stateArray) : new Set()
+        console.log('show_wikibooks() state: ', state) // DEBUG
+        if (state.has('R')) {
           // show wikipedia books button
           $('#wikibooks_tr').show().click(function () {
             const URL = chrome.runtime.getURL('booklist.html') + '?url=' + url


### PR DESCRIPTION
This fixes #551 so that Saving ('S') works on pages which are also Relevant Archived Resources ('R'). Once SPN finishes, normally it would show a check icon, but if it's also an 'R' page, it will go back to showing 'R' again. The blue buttons will also show correctly now during SPN.

I changed the data structure of the toolbar state so that instead of assigning a string such as 'R' 'S' or 'check' per tab, I assign a Set() of strings instead, to support multiple states per tab simultaneously.