### PR TITLE
Open Feedback URL Depending on Browser

### DIFF
--- a/about.html
+++ b/about.html
@@ -69,7 +69,7 @@
 
         <h3>Support</h3>
         <p>
-          <a href="https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak/reviews?hl=en">Write a Review</a><br>
+          <a id="reviews-page">Write a Review</a><br>
           <a href="https://archive.org/about/contact.php">Contact the Archive</a><br>
           <a href="https://archive.org/donate/">Donate to the Archive</a><br>
         </p>

--- a/about.html
+++ b/about.html
@@ -17,7 +17,7 @@
     <div class="row about-body">
       <div class="col-sm-7">
         <p>
-          In cooperation with <a href="https://summerofcode.withgoogle.com">Google Summer of Code</a>, The <a href="https://archive.org">Internet Archive</a> presents <em>The Official Wayback Machine Extension</em>. With the power of the Wayback Machine, we let you go back in time to see how a URL has changed and evolved through the history of the Web!
+          In cooperation with <a href="https://summerofcode.withgoogle.com" target="_blank">Google Summer of Code</a>, The <a href="https://archive.org" target="_blank">Internet Archive</a> presents <em>The Official Wayback Machine Extension</em>. With the power of the Wayback Machine, we let you go back in time to see how a URL has changed and evolved through the history of the Web!
         </p>
 
         <h3>Features</h3>
@@ -61,7 +61,7 @@
       <div class="col-sm-5">
         <h3>Version - <span id="version"></span></h3>
         <p>
-          <a href="https://web.archive.org">
+          <a href="https://web.archive.org" target="_blank">
             <!-- <img src="images/wayback-logo.png" style="width:180px"><br> -->
             Wayback Machine Website<br>
           </a>
@@ -69,9 +69,9 @@
 
         <h3>Support</h3>
         <p>
-          <a id="reviews-page">Write a Review</a><br>
-          <a href="https://archive.org/about/contact.php">Contact the Archive</a><br>
-          <a href="https://archive.org/donate/">Donate to the Archive</a><br>
+          <a id="reviews-page" target="_blank">Write a Review</a><br>
+          <a href="https://archive.org/about/contact.php" target="_blank">Contact the Archive</a><br>
+          <a href="https://archive.org/donate/" target="_blank">Donate to the Archive</a><br>
         </p>
         <p>
           <strong><em>Questions or Comments?</em></strong><br>
@@ -83,38 +83,38 @@
         <h3>Web Extensions</h3>
         <p>
           <img src="images/about/chrome64.png" class="about-app-icon" alt="Chrome Extension">
-          <a href="https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak">Chrome Extension</a><br>
+          <a href="https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak" target="_blank">Chrome Extension</a><br>
 
           <img src="images/about/safari64.png" class="about-app-icon" alt="Safari Extension">
-          <a href="https://apps.apple.com/us/app/wayback-machine/id1472432422">Safari Extension</a><br>
+          <a href="https://apps.apple.com/us/app/wayback-machine/id1472432422" target="_blank">Safari Extension</a><br>
 
           <img src="images/about/firefox64.png" class="about-app-icon" alt="Firefox Add-On">
-          <a href="https://addons.mozilla.org/en-US/firefox/addon/wayback-machine_new/">Firefox Add-On</a><br>
+          <a href="https://addons.mozilla.org/en-US/firefox/addon/wayback-machine_new/" target="_blank">Firefox Add-On</a><br>
 
           <h3>Mobile Apps</h3>
-          <a href="https://apps.apple.com/us/app/wayback-machine/id1201888313"><img src="images/about/app-store-badge.svg" class="about-badge" alt="Download on the Apple App Store"></a>
+          <a href="https://apps.apple.com/us/app/wayback-machine/id1201888313" target="_blank"><img src="images/about/app-store-badge.svg" class="about-badge" alt="Download on the Apple App Store"></a>
 
-          <a href="https://play.google.com/store/apps/details?id=com.archive.waybackmachine"><img src="images/about/google-play-badge.png" class="about-badge" alt="Get it on Google Play"></a>
+          <a href="https://play.google.com/store/apps/details?id=com.archive.waybackmachine" target="_blank"><img src="images/about/google-play-badge.png" class="about-badge" alt="Get it on Google Play"></a>
         </p>
 
         <h3>Credits</h3>
-        <p><a href="https://github.com/internetarchive/wayback-machine-chrome">Source Code on Github</a></p>
+        <p><a href="https://github.com/internetarchive/wayback-machine-chrome" target="_blank">Source Code on Github</a></p>
         <p>
-          Richard Caceres <a href="https://github.com/rchrd2">@rchrd2</a><br>
-          Rakesh Naga Chinta <a href="https://github.com/rakesh-chinta">@rakesh-chinta</a><br>
-          Abhishek Das <a href="https://github.com/abhidas17695">@abhidas17695</a><br>
-          Mark Graham <a href="https://github.com/markjgraham">@markjgraham</a><br>
-          Benjamin Mandel <a href="https://github.com/BenjaminMandel">@BenjaminMandel</a><br>
-          Anton Shiryaev <a href="https://github.com/Eagle19243">@Eagle19243</a><br>
-          Kumar Yogesh <a href="https://github.com/kumarjyogesh">@kumarjyogesh</a><br>
-          Vangelis Banos <a href="https://github.com/vbanos">@vbanos</a><br>
-          Max Reinisch <a href="https://github.com/maxreinisch">@MaxReinisch</a><br>
-          Anish Kumar Sarangi <a href="https://github.com/anishsarangi">@anishsarangi</a><br>
-          Pushkit Kapoor <a href="https://github.com/tikhsuP">@tikhsuP</a><br>
-          Carl Gorringe <a href="https://github.com/cgorringe">@cgorringe</a><br>
+          Richard Caceres <a href="https://github.com/rchrd2" target="_blank">@rchrd2</a><br>
+          Rakesh Naga Chinta <a href="https://github.com/rakesh-chinta" target="_blank">@rakesh-chinta</a><br>
+          Abhishek Das <a href="https://github.com/abhidas17695" target="_blank">@abhidas17695</a><br>
+          Mark Graham <a href="https://github.com/markjgraham" target="_blank">@markjgraham</a><br>
+          Benjamin Mandel <a href="https://github.com/BenjaminMandel" target="_blank">@BenjaminMandel</a><br>
+          Anton Shiryaev <a href="https://github.com/Eagle19243" target="_blank">@Eagle19243</a><br>
+          Kumar Yogesh <a href="https://github.com/kumarjyogesh" target="_blank">@kumarjyogesh</a><br>
+          Vangelis Banos <a href="https://github.com/vbanos" target="_blank">@vbanos</a><br>
+          Max Reinisch <a href="https://github.com/maxreinisch" target="_blank">@MaxReinisch</a><br>
+          Anish Kumar Sarangi <a href="https://github.com/anishsarangi" target="_blank">@anishsarangi</a><br>
+          Pushkit Kapoor <a href="https://github.com/tikhsuP" target="_blank">@tikhsuP</a><br>
+          Carl Gorringe <a href="https://github.com/cgorringe" target="_blank">@cgorringe</a><br>
           <br>
-          Site Map: <a href="http://www.rodden.org/kerry">Kerry Rodden</a><br>
-          Donate Icon: <a href="https://icon-library.net/icon/donate-icon-png-21.html">Free Icons Library</a><br>
+          Site Map: <a href="http://www.rodden.org/kerry" target="_blank">Kerry Rodden</a><br>
+          Donate Icon: <a href="https://icon-library.net/icon/donate-icon-png-21.html" target="_blank">Free Icons Library</a><br>
         </p>
 
         <h3>License</h3>

--- a/scripts/about.js
+++ b/scripts/about.js
@@ -1,6 +1,9 @@
-$(document).ready(function () {
-  const VERSION = chrome.runtime.getManifest().version
-  const DATE = new Date().getFullYear()
-  $('#version').text(VERSION)
-  $('#year').text(DATE)
-})
+//about.js
+
+// from 'utils.js'
+/*   global feedbackPageURL */
+const VERSION = chrome.runtime.getManifest().version
+const DATE = new Date().getFullYear()
+$('#version').text(VERSION)
+$('#year').text(DATE)
+$('#reviews-page').attr('href', feedbackPageURL)

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -1,7 +1,7 @@
 // popup.js
 
 // from 'utils.js'
-/*   global isValidUrl, isNotExcludedUrl, openByWindowSetting, hostURL */
+/*   global isValidUrl, isNotExcludedUrl, openByWindowSetting, hostURL, feedbackPageURL */
 
 function homepage() {
   openByWindowSetting('https://web.archive.org/')
@@ -229,8 +229,7 @@ function display_suggestions(e) {
   }
 }
 function open_feedback_page() {
-  var feedback_url = 'https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak/reviews?hl=en'
-  openByWindowSetting(feedback_url)
+  openByWindowSetting(feedbackPageURL)
 }
 
 function open_donations_page() {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -5,6 +5,7 @@ let isObject = (a) => (!!a) && (a.constructor === Object)
 
 let isFirefox = (navigator.userAgent.indexOf('Firefox') !== -1)
 const hostURL = isFirefox ? 'https://firefox-api.archive.org/' : 'https://chrome-api.archive.org/'
+const feedbackPageURL = isFirefox ? 'https://addons.mozilla.org/en-US/firefox/addon/wayback-machine_new/' : 'https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak/reviews?hl=en'
 
 /**
  * Convert given int to a string with metric suffix, separators localized.


### PR DESCRIPTION
This PR provides the following fix:
The **Feedback** button in the extension and the **Write a Review** option in the **About** page now open the appropriate feedback pages depending on the browser (Chrome/Firefox).