### PR TITLE
Clean URL when on 'web.archive.org'

### DIFF
--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -3,6 +3,7 @@ const expect = require('chai').expect
 const assert = require('assert').strict
 const getUrlByParameter = require('../webextension/scripts/utils').getUrlByParameter
 const isValidUrl = require('../webextension/scripts/utils').isValidUrl
+const get_clean_url = require('../webextension/scripts/utils').get_clean_url
 const isNotExcludedUrl = require('../webextension/scripts/utils').isNotExcludedUrl
 const badgeCountText = require('../webextension/scripts/utils').badgeCountText
 const timestampToDate = require('../webextension/scripts/utils').timestampToDate
@@ -39,13 +40,40 @@ describe('isValidUrl', () => {
   })
 })
 
+describe('get_clean_url', () => {
+  var test_cases = [
+    //Test Case when the URL is https://web.archive.org
+    { 'url': 'https://web.archive.org', 'result': 'https://web.archive.org' },
+
+    //Test Cases when the URL does not includes 'web.archive.org'
+    { 'url': 'https://www.google.com/', 'result': 'https://www.google.com/' },
+    { 'url': 'https://www.amazon.in/End-Days-Predictions-Prophecies-Thorndike/dp/1410407462', 'result': 'https://www.amazon.in/End-Days-Predictions-Prophecies-Thorndike/dp/1410407462' },
+    { 'url': 'http://purl.oclc.org/docs/inet96.html', 'result': 'http://purl.oclc.org/docs/inet96.html' },
+    { 'url': 'https://apnews.com/', 'result': 'https://apnews.com/' },
+
+    //Test Cases when the URL includes 'web.archive.org'
+    { 'url': 'https://web.archive.org/web/*/https://www.google.com/', 'result': 'https://www.google.com/' },
+    { 'url': 'https://web.archive.org/web/*/https://www.amazon.in/End-Days-Predictions-Prophecies-Thorndike/dp/1410407462', 'result': 'https://www.amazon.in/End-Days-Predictions-Prophecies-Thorndike/dp/1410407462' },
+    { 'url': 'https://web.archive.org/web/*/http://purl.oclc.org/docs/inet96.html', 'result': 'http://purl.oclc.org/docs/inet96.html' },
+    { 'url': 'https://web.archive.org/web/*/https://apnews.com/', 'result': 'https://apnews.com/' },
+    { 'url': 'https://web.archive.org/web/20200205001304/https://www.google.com/', 'result': 'https://www.google.com/' },
+    { 'url': 'https://web.archive.org/web/20200602155930/https://www.amazon.in/End-Days-Predictions-Prophecies-Thorndike/dp/1410407462', 'result': 'https://www.amazon.in/End-Days-Predictions-Prophecies-Thorndike/dp/1410407462' },
+    { 'url': 'https://web.archive.org/web/20200215123917/http://purl.oclc.org/docs/inet96.html', 'result': 'http://purl.oclc.org/docs/inet96.html' },
+    { 'url': 'https://web.archive.org/web/20200308013652/https://apnews.com/', 'result': 'https://apnews.com/' },
+  ]
+  test_cases.forEach(({ url, result }) => {
+    it('should return ' + result + ' on ' + url, () => {
+      expect(get_clean_url(url)).to.equal(result)
+    })
+  })
+})
+
 describe('isNotExcludedUrl', () => {
   var test_cases = [
     { 'url': 'https://0.0.0.0', 'result': false },
     { 'url': 'https://localhost', 'result': false },
     { 'url': 'https://127.0.0.1', 'result': false },
     { 'url': 'chrome-extension://efppkbphbfgoiaadblijkcdkdmajikhd/singleWindow.html?url=https://www.google.com/', 'result': false },
-    { 'url': 'https://chrome.google.com/webstore/category/extensions', 'result': false },
     { 'url': 'chrome://extensions', 'result': false },
     { 'url': 'chrome://newtab', 'result': false },
     { 'url': 'https://example.com', 'result': true },

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -4,7 +4,7 @@
 // Copyright 2016-2020, Internet Archive
 
 // from 'utils.js'
-/*   global isNotExcludedUrl, isValidUrl, notify, openByWindowSetting, sleep, wmAvailabilityCheck, hostURL, isFirefox */
+/*   global isNotExcludedUrl, get_clean_url, isValidUrl, notify, openByWindowSetting, sleep, wmAvailabilityCheck, hostURL, isFirefox */
 /*   global initDefaultOptions, afterAcceptOptions, viewableTimestamp, badgeCountText, getWaybackCount, newshosts */
 
 var manifest = chrome.runtime.getManifest()
@@ -364,7 +364,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true
   } else if (message.message === 'sendurl') {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      chrome.tabs.sendMessage(tabs[0].id, { url: tabs[0].url })
+      let url = get_clean_url(tabs[0].url)
+      chrome.tabs.sendMessage(tabs[0].id, { url: url })
     })
   } else if (message.message === 'changeBadge') {
     // used to change badge for auto-archive feature (not used?)
@@ -385,7 +386,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   } else if (message.message === 'updateCountBadge') {
     // update wayback count badge
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      updateWaybackCountBadge(tabs[0].id, tabs[0].url)
+      let url = get_clean_url(tabs[0].url)
+      updateWaybackCountBadge(tabs[0].id, url)
     })
   } else if (message.message === 'clearResource') {
     // resources settings unchecked
@@ -424,7 +426,7 @@ chrome.tabs.onUpdated.addListener((tabId, info, tab) => {
       chrome.storage.local.get(['auto_update_context', 'show_context', 'resource'], (event) => {
         chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
           if (event.resource === true) {
-            const url = tabs[0].url
+            const url = get_clean_url(tabs[0].url)
             const tabId = tabs[0].id
             const news_host = new URL(url).hostname
             // checking resource of amazon books
@@ -653,10 +655,11 @@ chrome.contextMenus.create({
   'contexts': ['all'],
   'documentUrlPatterns': ['*://*/*', 'ftp://*/*']
 })
+
 chrome.contextMenus.onClicked.addListener((click) => {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     if (['first', 'recent', 'save', 'all'].indexOf(click.menuItemId) >= 0) {
-      const page_url = tabs[0].url
+      const page_url = get_clean_url(tabs[0].url)
       let wayback_url
       let wmIsAvailable = true
       if (isValidUrl(page_url) && isNotExcludedUrl(page_url)) {

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -418,7 +418,7 @@ chrome.tabs.onUpdated.addListener((tabId, info, tab) => {
   } else if (info.status === 'loading') {
     var received_url = tab.url
     clearToolbarState(tab.id)
-    if (isNotExcludedUrl(received_url) && !(received_url.includes('alexa.com') || received_url.includes('whois.com') || received_url.includes('twitter.com') || received_url.includes('oauth'))) {
+    if (isNotExcludedUrl(received_url) && !received_url.includes('web.archive.org') && !(received_url.includes('alexa.com') || received_url.includes('whois.com') || received_url.includes('twitter.com') || received_url.includes('oauth'))) {
       let contextUrl = received_url
       received_url = received_url.replace(/^https?:\/\//, '')
       var open_url = received_url

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -403,8 +403,8 @@ function clearFocus() {
 function setupWaybackCount() {
   chrome.storage.local.get(['wm_count'], (event) => {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      let url = get_clean_url(tabs[0].url)
-      if ((event.wm_count === true) && isValidUrl(url) && isNotExcludedUrl(url)) {
+      let url = tabs[0].url
+      if ((event.wm_count === true) && isValidUrl(url) && isNotExcludedUrl(url) && !url.includes('web.archive.org')) {
         $('#wayback-count-label').show()
         showWaybackCount(url)
         chrome.runtime.sendMessage({ message: 'updateCountBadge' })

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -143,7 +143,8 @@ function search_box_activate() {
   const search_box = document.getElementById('search-input')
   search_box.addEventListener('keydown', (e) => {
     if ((e.keyCode === 13 || e.which === 13) && (search_box.value.length > 1) && isNotExcludedUrl(search_box.value)) {
-      openByWindowSetting('https://web.archive.org/web/*/' + search_box.value)
+      let searchValue = get_clean_url(search_box.value)
+      openByWindowSetting('https://web.archive.org/web/*/' + searchValue)
     }
   })
 }

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -1,7 +1,7 @@
 // popup.js
 
 // from 'utils.js'
-/*   global isValidUrl, isNotExcludedUrl, openByWindowSetting, hostURL, feedbackPageURL, newshosts, dateToTimestamp */
+/*   global isValidUrl, isNotExcludedUrl, get_clean_url, openByWindowSetting, hostURL, feedbackPageURL, newshosts, dateToTimestamp */
 
 function homepage() {
   openByWindowSetting('https://web.archive.org/')
@@ -9,7 +9,7 @@ function homepage() {
 
 function save_now() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    let url = tabs[0].url
+    let url = get_clean_url(tabs[0].url)
     let options = ['capture_all']
     if ($('#chk-outlinks').prop('checked') === true) {
       options.push('capture_outlinks')
@@ -43,7 +43,7 @@ function last_save() {
     } else {
       $('#save_now').removeAttr('disabled')
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-        let url = tabs[0].url
+        let url = get_clean_url(tabs[0].url)
         chrome.runtime.sendMessage({
           message: 'getLastSaveTime',
           page_url: url
@@ -68,7 +68,7 @@ function checkAuthentication(callback) {
 
 function recent_capture() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    let url = tabs[0].url
+    let url = get_clean_url(tabs[0].url)
     chrome.runtime.sendMessage({
       message: 'openurl',
       wayback_url: 'https://web.archive.org/web/2/',
@@ -80,7 +80,7 @@ function recent_capture() {
 
 function first_capture() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    let url = tabs[0].url
+    let url = get_clean_url(tabs[0].url)
     chrome.runtime.sendMessage({
       message: 'openurl',
       wayback_url: 'https://web.archive.org/web/0/',
@@ -92,7 +92,7 @@ function first_capture() {
 
 function view_all() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    let url = tabs[0].url
+    let url = get_clean_url(tabs[0].url)
     chrome.runtime.sendMessage({
       message: 'openurl',
       wayback_url: 'https://web.archive.org/web/*/',
@@ -113,9 +113,9 @@ function social_share(eventObj) {
   let recent_url = 'https://web.archive.org/web/' + timestamp + '/'
 
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    let url = tabs[0].url
+    let url = get_clean_url(tabs[0].url)
     let sharing_url = recent_url + url
-    if (isNotExcludedUrl(url)) {
+    if (isNotExcludedUrl(url)) { // Prevents sharing some unnecessary page
       if (id.includes('fb')) {
         openByWindowSetting('https://www.facebook.com/sharer/sharer.php?u=' + sharing_url)
       } else if (id.includes('twit')) {
@@ -129,7 +129,7 @@ function social_share(eventObj) {
 
 function search_tweet() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    let url = tabs[0].url
+    let url = get_clean_url(tabs[0].url)
     if (isNotExcludedUrl(url)) {
       url = url.replace(/^https?:\/\//, '')
       if (url.slice(-1) === '/') url = url.substring(0, url.length - 1)
@@ -245,7 +245,7 @@ function about_support() {
 
 function sitemap() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    let url = tabs[0].url
+    let url = get_clean_url(tabs[0].url)
     if (isNotExcludedUrl(url)) { openByWindowSetting('https://web.archive.org/web/sitemap/' + url) }
   })
 }
@@ -257,7 +257,7 @@ function settings() {
 
 function show_all_screens() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    let url = tabs[0].url
+    let url = get_clean_url(tabs[0].url)
     chrome.runtime.sendMessage({ message: 'showall', url: url })
   })
 }
@@ -397,7 +397,7 @@ function clearFocus() {
 function setupWaybackCount() {
   chrome.storage.local.get(['wm_count'], (event) => {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      let url = tabs[0].url
+      let url = get_clean_url(tabs[0].url)
       if ((event.wm_count === true) && isValidUrl(url) && isNotExcludedUrl(url)) {
         $('#wayback-count-label').show()
         showWaybackCount(url)

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -113,8 +113,13 @@ function social_share(eventObj) {
   let recent_url = 'https://web.archive.org/web/' + timestamp + '/'
 
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    let url = get_clean_url(tabs[0].url)
-    let sharing_url = recent_url + url
+    let url = tabs[0].url
+    let sharing_url
+    if (url.includes('web.archive.org')) {
+      sharing_url = url // If the user is already at a playback page,share that URL
+    } else {
+      sharing_url = recent_url + get_clean_url(url) // When not on a playback page,share the recent archived version of that URL
+    }
     if (isNotExcludedUrl(url)) { // Prevents sharing some unnecessary page
       if (id.includes('fb')) {
         openByWindowSetting('https://www.facebook.com/sharer/sharer.php?u=' + sharing_url)

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -128,7 +128,6 @@ const excluded_urls = [
   'chrome:',
   'chrome.google.com/webstore',
   'chrome-extension:',
-  'web.archive.org',
   'about:',
   'moz-extension:',
   '192.168.',
@@ -145,6 +144,33 @@ function isNotExcludedUrl(url) {
     }
   }
   return true
+}
+
+function remove_port(url) {
+  if (url.substr(-4) === ':80/') {
+    url = url.substring(0, url.length - 4)
+  }
+  return url
+}
+
+function remove_wbm(url) {
+  let pos = url.indexOf('/http')
+  let new_url = ''
+  if (pos !== -1) {
+    new_url = url.substring(pos + 1)
+  } else {
+    pos = url.indexOf('/www')
+    new_url = url.substring(pos + 1)
+  }
+  return remove_port(new_url)
+}
+
+// Function to clean the URL if the user is on 'web.archive.org'
+function get_clean_url(url) {
+  if (url.includes('web.archive.org')) {
+    url = remove_wbm(url)
+  }
+  return url
 }
 
 /**
@@ -377,6 +403,7 @@ if (typeof module !== 'undefined') {
     getWaybackUrlFromResponse,
     isValidUrl,
     isNotExcludedUrl,
+    get_clean_url,
     wmAvailabilityCheck,
     openByWindowSetting,
     sleep,

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -126,7 +126,6 @@ const excluded_urls = [
   '0.0.0.0',
   '127.0.0.1',
   'chrome:',
-  'chrome.google.com/webstore',
   'chrome-extension:',
   'about:',
   'moz-extension:',


### PR DESCRIPTION
 - [x] Return to treating web.archive.org URLs as a special case, and using the extracted URL to act on the following:

- Fetching the WB Count / Badge Count

- SPN (in the Popup as well as in the right click menu)

- Oldest/Overview/Newest (in the Popup as well as in the right click menu)

- Site Map

- Related Tweets

- Show Contexts

- Social Share

- Search Box