### PR TITLE
Fix Context screen bugs

### DIFF
--- a/webextension/context.html
+++ b/webextension/context.html
@@ -89,7 +89,7 @@
         <div class="loader" id="loader_alexa"></div>
         <div class="col-sm-6">
           <div class="pre" id="show_alexa_data" style="display:none;">
-            <div><b>URL: </b><span class="color_code" id="alexa_name"></span></div>
+            <div><b>Domain: </b><span class="color_code" id="alexa_name"></span></div>
             <div class="rank"><b>Alexa Rank: </b><span class="color_code" id="alexa_rank"></span></div>
             <div class="country"><b>Country: </b><span class="color_code" id="alexa_country"></span></div>
             <div class="error"></div>

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "3.0.0.4",
+  "version": "3.0.0.5",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/alexa.js
+++ b/webextension/scripts/alexa.js
@@ -5,9 +5,8 @@
 
 function get_alexa () {
   var alexa_url = 'https://xml.alexa.com/data?cli=10&dat=n&url='
-  var url = getUrlByParameter('url')
-  url = url.replace(/^https?:\/\//, '')
-  $.get(alexa_url + url, (xml) => {
+  var url = new URL(getUrlByParameter('url'))
+  $.get(alexa_url + url.hostname, (xml) => {
     var name = xml.getElementsByTagName('ALEXA')[0].getAttribute('URL')
     $('#alexa_name').text(name)
     var details = xml.getElementsByTagName('SD')[0]
@@ -52,7 +51,7 @@ function get_alexa () {
     } else {
       $('.related_sites').hide()
     }
-    $('#alexa_page').attr('href', 'https://archive.org/services/context/alexa?url=' + url)
+    $('#alexa_page').attr('href', 'https://archive.org/services/context/alexa?url=' + url.hostname)
     $('#loader_alexa').hide()
     $('#show_alexa_data').show()
   })

--- a/webextension/scripts/alexa.js
+++ b/webextension/scripts/alexa.js
@@ -5,7 +5,7 @@
 
 function get_alexa () {
   var alexa_url = 'https://xml.alexa.com/data?cli=10&dat=n&url='
-  var url = new URL(getUrlByParameter('url'))
+  var url = new URL(decodeURIComponent(getUrlByParameter('url')))
   $.get(alexa_url + url.hostname, (xml) => {
     var name = xml.getElementsByTagName('ALEXA')[0].getAttribute('URL')
     $('#alexa_name').text(name)

--- a/webextension/scripts/annotation.js
+++ b/webextension/scripts/annotation.js
@@ -23,7 +23,7 @@ function hypothesis_api_url (url, type) {
  * Get hypothes.is data and render results.
  */
 function get_annotations (type = 'url') {
-  const url = getUrlByParameter('url')
+  const url = decodeURIComponent(getUrlByParameter('url'))
   const new_url = hypothesis_api_url(url, type)
   $.getJSON(new_url, (data) => {
     const length = data.rows.length

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -386,7 +386,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   } else if (message.message === 'changeBadge') {
     // used to change badge for auto-archive feature (not used?)
   } else if (message.message === 'showall' && isNotExcludedUrl(message.url)) {
-    const context_url = chrome.runtime.getURL('context.html') + '?url=' + message.url
+    const context_url = chrome.runtime.getURL('context.html') + '?url=' + encodeURIComponent(message.url)
     tabIdPromise = new Promise((resolve) => {
       openByWindowSetting(context_url, null, resolve)
     })
@@ -469,7 +469,7 @@ chrome.tabs.onUpdated.addListener((tabId, info, tab) => {
           if (tabIdPromise) {
             tabIdPromise.then((id) => {
               if (tabId !== id && tab.id !== id && isNotExcludedUrl(contextUrl)) {
-                chrome.tabs.update(id, { url: chrome.runtime.getURL('context.html') + '?url=' + contextUrl })
+                chrome.tabs.update(id, { url: chrome.runtime.getURL('context.html') + '?url=' + encodeURIComponent(contextUrl) })
               }
             })
           }
@@ -495,7 +495,7 @@ chrome.tabs.onActivated.addListener((info) => {
       if ((event.auto_update_context === true) && tabIdPromise) {
         tabIdPromise.then((id) => {
           if (info.tabId === tab.id && tab.tabId !== id && tab.url && isNotExcludedUrl(tab.url)) {
-            chrome.tabs.update(id, { url: chrome.runtime.getURL('context.html') + '?url=' + tab.url })
+            chrome.tabs.update(id, { url: chrome.runtime.getURL('context.html') + '?url=' + encodeURIComponent(tab.url) })
           }
         })
       }

--- a/webextension/scripts/context.js
+++ b/webextension/scripts/context.js
@@ -18,7 +18,7 @@
 // from 'overview.js'
 /*   global get_WBMSummary */
 
-const url = getUrlByParameter('url')
+const url = decodeURIComponent(getUrlByParameter('url'))
 
 function get_tagCloud() {
   get_tags(url)

--- a/webextension/scripts/domaintools.js
+++ b/webextension/scripts/domaintools.js
@@ -14,7 +14,7 @@ function appendToParent (id, item, text_before, parent, show_item, text_after) {
 }
 
 function get_domainTool () {
-  let url = getUrlByParameter('url')
+  let url = decodeURIComponent(getUrlByParameter('url'))
   let domaintools_api = hostURL+'context/domaintools?url=' + url
   $.getJSON(domaintools_api, (data) => {
     let parent = $('#show_domaintools_data')

--- a/webextension/scripts/overview.js
+++ b/webextension/scripts/overview.js
@@ -27,7 +27,7 @@ function get_details (url) {
     .text(captures.toLocaleString())
     if (captures > 0) {
       $('#total_captures').show()
-      get_thumbnail()
+      get_thumbnail(url)
     } else {
       $('#loader_thumbnail').hide()
       $('#show_thumbnail').text('Thumbnail not found.')

--- a/webextension/scripts/overview.js
+++ b/webextension/scripts/overview.js
@@ -4,14 +4,14 @@
 /*   global getUrlByParameter, hostURL, getWaybackCount, timestampToDate */
 
 function get_WBMSummary () {
-  get_details()
-  first_archive_details()
-  recent_archive_details()
+  var url = decodeURIComponent(getUrlByParameter('url'))
+  get_details(url)
+  first_archive_details(url)
+  recent_archive_details(url)
   $('#loader_wbmsummary').hide()
 }
 
-function get_details () {
-  var url = getUrlByParameter('url')
+function get_details (url) {
   var new_url = hostURL + 'services/context/metadata?url=' + url
   $.getJSON(new_url, (response) => {
     if ('type' in response) {
@@ -35,8 +35,7 @@ function get_details () {
   })
 }
 
-function first_archive_details () {
-  var url = getUrlByParameter('url')
+function first_archive_details (url) {
   var new_url = hostURL + 'cdx/search?url=' + url + '&limit=1&output=json'
   $.getJSON(new_url, (data) => {
     if (data.length === 0) {
@@ -52,8 +51,7 @@ function first_archive_details () {
   .fail(() => $('#first_archive_datetime_error').text('Data not available'))
 }
 
-function recent_archive_details () {
-  var url = getUrlByParameter('url')
+function recent_archive_details (url) {
   var new_url = hostURL + 'cdx/search?url=' + url + '&limit=-1&output=json'
   $.getJSON(new_url, (data) => {
     if (data.length === 0) {
@@ -69,8 +67,7 @@ function recent_archive_details () {
   .fail(() => $('#recent_archive_datetime_error').text('Data not available'))
 }
 // Function used to get the thumbnail of the URL
-function get_thumbnail () {
-  var url = getUrlByParameter('url')
+function get_thumbnail (url) {
   var new_url = 'http://crawl-services.us.archive.org:8200/wayback?url=' + url + '&width=300&height=200'
   $('#loader_thumbnail').show()
   fetch(new_url)

--- a/webextension/scripts/overview.js
+++ b/webextension/scripts/overview.js
@@ -39,7 +39,7 @@ function first_archive_details (url) {
   var new_url = hostURL + 'cdx/search?url=' + url + '&limit=1&output=json'
   $.getJSON(new_url, (data) => {
     if (data.length === 0) {
-      $('#first_archive_datetime_error').text('Data not available')
+      $('#first_archive_datetime_error').text('URL has not been archived')
     } else {
       const ts = data[1][1]
       const dt = timestampToDate(ts).toString().split('+')[0]
@@ -55,7 +55,7 @@ function recent_archive_details (url) {
   var new_url = hostURL + 'cdx/search?url=' + url + '&limit=-1&output=json'
   $.getJSON(new_url, (data) => {
     if (data.length === 0) {
-      $('#recent_archive_datetime_error').text('Data not available')
+      $('#recent_archive_datetime_error').text('URL has not been archived')
     } else {
       const ts = data[1][1]
       const dt = timestampToDate(ts).toString().split('+')[0]

--- a/webextension/scripts/tagcloud_loader.js
+++ b/webextension/scripts/tagcloud_loader.js
@@ -7,6 +7,6 @@
 /*   global get_tags */
 
 window.onload = () => {
-  var url = getUrlByParameter('url')
+  var url = decodeURIComponent(getUrlByParameter('url'))
   get_tags(url)
 }


### PR DESCRIPTION
This PR fixes the bugs on Context pages:

- [x]  Alexa Overview should only work on the domain name. Anything after should be stripped.
- [x] When passing the url value on the internal context.html URL, the url needs to be encoded to support ? characters.
- [x] Check to make sure Wayback Captures Overview works correctly on URLs that are not in the archive, and display an appropriate message. Could hide the usual message and display one that says that the URL has not been archived.