### PR TITLE
Exclude UP & DOWN keys from event

### DIFF
--- a/webextension/css/doi.css
+++ b/webextension/css/doi.css
@@ -9,7 +9,7 @@
 #container-whole-doi > div {
     background-color: #eee;
     border-radius: 5px;
-    border: 1px solid black;
+    border: 1px solid #888;
     margin: 10px auto;
     padding: 5px;
     justify-content: space-between;
@@ -104,5 +104,9 @@ button:hover {
 
   h2, h3, h4 {
       color: #bbb;
+  }
+
+  #container-whole-doi > div {
+      background-color: #333;
   }
 }

--- a/webextension/css/index.css
+++ b/webextension/css/index.css
@@ -97,6 +97,7 @@ body {
     border-radius: 5px;
     word-break: break-all;
 }
+
 #suggestion-box div {
     padding: 3px 10px;
 }
@@ -370,6 +371,16 @@ a.btn-social, .btn-social {
         background-color: #222;
         border-color: #666;
         color: #ddd;
+    }
+
+    #suggestion-box {
+        background-color: #2C2C2C;
+        color: #eee;
+        border: 1px solid #666;
+    }
+
+    #suggestion-box div:hover, .focused {
+        background-color: #666;
     }
 
     #wayback-count-label, #url-not-supported-message, #using-search-url {

--- a/webextension/css/index.css
+++ b/webextension/css/index.css
@@ -58,8 +58,7 @@ body {
 /* general */
 
 .focused {
-    background-color: #D3D3D3;
-    opacity: 0.7;
+    background-color: #eee;
 }
 
 .resize-fit-center {
@@ -85,14 +84,24 @@ body {
 #search-input {
     display: block;
     position: relative;
+    border-radius: 5px;
     z-index: 1;
 }
 
+/* suggestions box */
+
 #suggestion-box {
     display: none;
-    max-height: 300px;
-    min-width: 100%;
-    overflow: auto;
+    max-height: 350px;
+    width: 166px;
+    border-radius: 5px;
+    word-break: break-all;
+}
+#suggestion-box div {
+    padding: 3px 10px;
+}
+#suggestion-box div:hover {
+    background-color: #eee;
 }
 
 /* checkboxes */

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -38,8 +38,8 @@
                   style="border-color: transparent; bottom: 0px; box-shadow: none; color: rgb(165, 165, 165); display: block; position: absolute; top: 0px; width: 100%; z-index: 0;">
 -->
               </div>
-              <ul id="suggestion-box" class="dropdown-menu bootstrap-typeahead-menu dropdown-menu-left">
-              </ul>
+              <div id="suggestion-box" class="dropdown-menu bootstrap-typeahead-menu dropdown-menu-left">
+              </div>
             </div>
             <input type="submit" tabindex="-1" style="position: absolute; left: -9999px; width: 1px; height: 1px;">
           </form>

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -126,7 +126,7 @@ async function validate_spn(tabId, job_id, silent = false, page_url) {
       addToolbarState(tabId, 'S')
     }
 
-    await sleep(1000)
+    await sleep(6000)
     const timeoutPromise = new Promise((resolve, reject) => {
       setTimeout(() => {
         reject(new Error('timeout'))

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -675,7 +675,7 @@ chrome.contextMenus.create({
 chrome.contextMenus.onClicked.addListener((click) => {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     if (['first', 'recent', 'save', 'all'].indexOf(click.menuItemId) >= 0) {
-      const page_url = get_clean_url(tabs[0].url)
+      const page_url = get_clean_url(click.linkUrl) || get_clean_url(tabs[0].url)
       let wayback_url
       let wmIsAvailable = true
       if (isValidUrl(page_url) && isNotExcludedUrl(page_url)) {

--- a/webextension/scripts/doi.js
+++ b/webextension/scripts/doi.js
@@ -83,7 +83,7 @@ function makeEntry (data) {
 function createPage () {
   let container = $('#container-whole-doi')
   const url = getUrlByParameter('url')
-  $.getJSON(hostURL + 'context/papers?url=' + url, (response) => {
+  $.getJSON(hostURL + 'services/context/papers?url=' + url, (response) => {
     $('.loader').hide()
     if (response.status && response.status === 'error') {
       $('#doi-heading').html(response.message)

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -174,9 +174,11 @@ function useSearchBox() {
 function search_box_activate() {
   const search_box = document.getElementById('search-input')
   search_box.addEventListener('keyup', (e) => {
-    if ((search_box.value.length > 0) && isNotExcludedUrl(search_box.value)) {
+    // exclude UP and DOWN keys from event
+    if (!(e.keyCode === 38 || e.which === 38 || e.keyCode === 40 || e.which === 40) && (search_box.value.length >= 0) && isNotExcludedUrl(search_box.value)) {
       searchValue = get_clean_url(makeValidURL(search_box.value))
-      if (searchValue) { useSearchBox() }
+      // use searchValue if it is valid, else update UI
+      searchValue ? useSearchBox() : $('#using-search-url').hide()
     }
   })
 }
@@ -255,17 +257,8 @@ function display_suggestions(e) {
   } else {
     // setTimeout is used to get the text in the text field after key has been pressed
     window.setTimeout(() => {
-      if ($('#search-input').val().length >= 1) {
-        $('#url-not-supported-message').hide()
-      } else {
-        $('#url-not-supported-message').show()
-        $('#using-search-url').hide()
-      }
-      if ($('#search-input').val().length >= 3) {
-        display_list($('#search-input').val())
-      } else {
-        $('#suggestion-box').text('').hide()
-      }
+      $('#search-input').val().length >= 1 ? $('#url-not-supported-message').hide() : $('#url-not-supported-message').show()
+      $('#search-input').val().length >= 3 ? display_list($('#search-input').val()) : $('#suggestion-box').text('').hide()
     }, 0.1)
   }
 }

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -174,7 +174,7 @@ function useSearchBox() {
 function search_box_activate() {
   const search_box = document.getElementById('search-input')
   search_box.addEventListener('keyup', (e) => {
-    // exclude UP and DOWN keys from event
+    // exclude UP and DOWN keys from keyup event
     if (!(e.keyCode === 38 || e.which === 38 || e.keyCode === 40 || e.which === 40) && (search_box.value.length >= 0) && isNotExcludedUrl(search_box.value)) {
       searchValue = get_clean_url(makeValidURL(search_box.value))
       // use searchValue if it is valid, else update UI
@@ -257,7 +257,9 @@ function display_suggestions(e) {
   } else {
     // setTimeout is used to get the text in the text field after key has been pressed
     window.setTimeout(() => {
-      $('#search-input').val().length >= 1 ? $('#url-not-supported-message').hide() : $('#url-not-supported-message').show()
+      // hide 'URL Not Supported' text when anything is entered in search box
+      $('#search-input').val().length >= 1 ? $('#url-not-supported-message').hide() : ( $('#url-not-supported-message').show(), $('#using-search-url').hide() )
+      // display suggestions list
       $('#search-input').val().length >= 3 ? display_list($('#search-input').val()) : $('#suggestion-box').text('').hide()
     }, 0.1)
   }

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -248,6 +248,7 @@ function display_list(key_word) {
   })
 }
 
+let timer
 function display_suggestions(e) {
   // exclude arrow keys from keypress event
   if (e.keyCode === 38 || e.keyCode === 40) { return false }
@@ -255,13 +256,17 @@ function display_suggestions(e) {
   if (e.keyCode === 13) {
     e.preventDefault()
   } else {
-    // setTimeout is used to get the text in the text field after key has been pressed
-    window.setTimeout(() => {
-      // hide 'URL Not Supported' text when anything is entered in search box
-      $('#search-input').val().length >= 1 ? $('#url-not-supported-message').hide() : ( $('#url-not-supported-message').show(), $('#using-search-url').hide() )
-      // display suggestions list
-      $('#search-input').val().length >= 3 ? display_list($('#search-input').val()) : $('#suggestion-box').text('').hide()
-    }, 0.1)
+    if ($('#search-input').val().length >= 1) {
+      $('#url-not-supported-message').hide()
+    } else {
+      $('#url-not-supported-message').show()
+      $('#using-search-url').hide()
+    }
+    clearTimeout(timer)
+    //Call display_list function if the difference between keypress is greater than 300ms (Debouncing) 
+    timer = setTimeout(()=>{
+      display_list($('#search-input').val())
+    }, 300)
   }
 }
 

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -236,13 +236,13 @@ function display_list(key_word) {
       $('#suggestion-box').show()
       arrow_key_access()
       for (var i = 0; i < data.hosts.length; i++) {
-        $('#suggestion-box').append($('<li>').append(
-          $('<a>').attr('role', 'button').text(data.hosts[i].display_name).click((event) => {
+        $('#suggestion-box').append(
+          $('<div>').attr('role', 'button').text(data.hosts[i].display_name).click((event) => {
             document.getElementById('search-input').value = event.target.innerHTML
             searchValue = get_clean_url(makeValidURL(event.target.innerHTML))
             if (searchValue) { useSearchBox() }
           })
-        ))
+        )
       }
     }
   })


### PR DESCRIPTION
1. Fixes [this](https://github.com/internetarchive/wayback-machine-chrome/pull/619#pullrequestreview-451174366), enabling the user to go further down the search-box list.
2. Hides "Using Search URL" text when not using search box url.