### PR TITLE
Remove max-height of popup

### DIFF
--- a/webextension/css/index.css
+++ b/webextension/css/index.css
@@ -3,7 +3,6 @@
 
 body {
     width: 200px;
-    max-height: 538px;
     background-color: #eee;
     color: #222;
 }


### PR DESCRIPTION
This PR removes the max-height of the popup.
This is needed for firefox as we would not like to have scrollbars in our extension

![Screenshot (145)](https://user-images.githubusercontent.com/42881874/88811564-56ef0b80-d1d4-11ea-8600-b822a46c9853.png)
