### PR TITLE
Resource-list showing bug fixed

### DIFF
--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -83,6 +83,15 @@ function savePageNow(tabId, page_url, silent = false, options = []) {
             if (result.show_resource_list === true) {
               const resource_list_url = chrome.runtime.getURL('resource_list.html') + '?url=' + page_url + '&job_id=' + res.job_id + '#not_refreshed'
               openByWindowSetting(resource_list_url, 'windows')
+              if (res.status === 'error') {
+                setTimeout(() => {
+                  chrome.runtime.sendMessage({
+                    message: 'resource_list_show_error',
+                    data: res,
+                    url: page_url
+                  })
+                }, 3000)
+              }
             }
           })
         }
@@ -121,7 +130,7 @@ async function validate_spn(tabId, job_id, silent = false, page_url) {
   let status = 'start'
   const val_data = new URLSearchParams()
   val_data.append('job_id', job_id)
-  let wait_time = 1000;
+  let wait_time = 1000
   while ((status === 'start') || (status === 'pending')) {
     // update UI
     chrome.runtime.sendMessage({

--- a/webextension/scripts/resource_list.js
+++ b/webextension/scripts/resource_list.js
@@ -22,9 +22,7 @@ function show_resource_data(url_name) {
   $('#current-url').text(url_name)
   chrome.runtime.onMessage.addListener(
     (message) => {
-      console.log('received message')
       if (message.message === 'resource_list_show' && message.url === url_name) {
-        console.log('here')
         vdata = message.data
         status = message.data.status
         $('#current-status').text(status_list[status])
@@ -60,8 +58,7 @@ function show_resource_data(url_name) {
           showError()
           document.location.hash = '#refreshed'
         }
-      } else {
-        console.log('hey')
+      } else if (message.message === 'resource_list_show_error' && message.url === url_name) {
         showError(message.data.message)
       }
     }

--- a/webextension/scripts/resource_list.js
+++ b/webextension/scripts/resource_list.js
@@ -1,7 +1,6 @@
 window.onload = () => {
   var url = new URL(window.location.href)
   var url_name = url.searchParams.get('url')
-  console.log(document.location.hash)
   if (document.location.hash === '#not_refreshed') {
     show_resource_data(url_name)
   } else {
@@ -23,7 +22,9 @@ function show_resource_data(url_name) {
   $('#current-url').text(url_name)
   chrome.runtime.onMessage.addListener(
     (message) => {
+      console.log('received message')
       if (message.message === 'resource_list_show' && message.url === url_name) {
+        console.log('here')
         vdata = message.data
         status = message.data.status
         $('#current-status').text(status_list[status])
@@ -59,6 +60,9 @@ function show_resource_data(url_name) {
           showError()
           document.location.hash = '#refreshed'
         }
+      } else {
+        console.log('hey')
+        showError(message.data.message)
       }
     }
   )


### PR DESCRIPTION
BUG :
For some URLs, "Resource List" feature doesn't works as expected.
To replicate, make sure you have selected the 'Show Resources During Save' option in 'General' settings.
Example 1: Visit  http://brainsters.in/  and Save the page.
Example 2: Visit  https://web.archive.org/  and Save the Page.

Above bug is fixed in this PR !