### PR TITLE
Add 'edition.cnn.com' to newshosts

### DIFF
--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -31,7 +31,8 @@ const newshosts = new Set([
   'www.theverge.com',
   'www.usatoday.com',
   'www.vox.com',
-  'www.washingtonpost.com'
+  'www.washingtonpost.com',
+  'edition.cnn.com'
 ])
 
 let isArray = (a) => (!!a) && (a.constructor === Array)


### PR DESCRIPTION
This PR adds 'edition.cnn.com' to `newshosts` which enables the detection of TV News Clips for this website.