### PR TITLE
Use browser names dynamically, instead of using API URLs

### DIFF
--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -4,7 +4,7 @@
 // Copyright 2016-2020, Internet Archive
 
 // from 'utils.js'
-/*   global isNotExcludedUrl, get_clean_url, isValidUrl, notify, openByWindowSetting, sleep, wmAvailabilityCheck, hostURL, isFirefox */
+/*   global isNotExcludedUrl, get_clean_url, isValidUrl, notify, openByWindowSetting, sleep, wmAvailabilityCheck, hostBrowser, isFirefox */
 /*   global initDefaultOptions, afterAcceptOptions, viewableTimestamp, badgeCountText, getWaybackCount, newshosts */
 
 var manifest = chrome.runtime.getManifest()
@@ -15,7 +15,7 @@ var globalStatusCode = ''
 let gToolbarStates = {}
 let waybackCountCache = {}
 let tabIdPromise
-var WB_API_URL = hostURL + 'wayback/available'
+var WB_API_URL = 'https://' + hostBrowser + '-api.archive.org/' + 'wayback/available'
 var fact_checked_data = new Map()
 const SPN_RETRY = 6000
 
@@ -63,7 +63,7 @@ function savePageNow(tabId, page_url, silent = false, options = []) {
       setTimeout(() => {
         reject(new Error('timeout'))
       }, 30000)
-      fetch(hostURL + 'save/',
+      fetch('https://' + hostBrowser + '-api.archive.org/' + 'save/',
         {
           credentials: 'include',
           method: 'POST',
@@ -114,7 +114,7 @@ function authCheckAPI() {
     setTimeout(() => {
       reject(new Error('timeout'))
     }, 30000)
-    fetch(hostURL + 'save/', {
+    fetch('https://' + hostBrowser + '-api.archive.org/' + 'save/', {
       credentials: 'include',
       method: 'POST',
       headers: { 'Accept': 'application/json' }
@@ -145,7 +145,7 @@ async function validate_spn(tabId, job_id, silent = false, page_url) {
         reject(new Error('timeout'))
       }, 30000)
       if ((status === 'start') || (status === 'pending')) {
-        fetch(hostURL + 'save/status', {
+        fetch('https://' + hostBrowser + '-api.archive.org/' + 'save/status', {
           credentials: 'include',
           method: 'POST',
           body: val_data,
@@ -428,7 +428,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true
   } else if (message.message === 'getWikipediaBooks') {
     // wikipedia message listener
-    let host = hostURL + 'services/context/books?url='
+    let host = 'https://' + hostBrowser + '-api.archive.org/' + 'services/context/books?url='
     let url = host + encodeURIComponent(message.query)
     // Encapsulate fetch with a timeout promise object
     const timeoutPromise = new Promise((resolve, reject) => {
@@ -442,7 +442,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       .then(data => sendResponse(data))
     return true
   } else if (message.message === 'tvnews') {
-    let url = hostURL + 'services/context/tvnews?url=' + message.article
+    let url = 'https://' + hostBrowser + '-api.archive.org/' + 'services/context/tvnews?url=' + message.article
     const timeoutPromise = new Promise((resolve, reject) => {
       setTimeout(() => {
         reject(new Error('timeout'))
@@ -550,7 +550,7 @@ chrome.tabs.onUpdated.addListener((tabId, info, tab) => {
               const news_host = new URL(url).hostname
               // checking resource of amazon books
               if (url.includes('www.amazon')) {
-                fetch(hostURL + 'services/context/amazonbooks?url=' + url)
+                fetch('https://' + hostBrowser + '-api.archive.org/' + 'services/context/amazonbooks?url=' + url)
                   .then(resp => resp.json())
                   .then(resp => {
                     if (('metadata' in resp && 'identifier' in resp['metadata']) || 'ocaid' in resp) {

--- a/webextension/scripts/doi.js
+++ b/webextension/scripts/doi.js
@@ -1,7 +1,7 @@
 // doi.js
 
 // from 'utils.js'
-/*   global getUrlByParameter */
+/*   global getUrlByParameter, hostBrowser */
 
 function getMetadata(entry) {
   const MAX_TITLE_LEN = 300
@@ -83,7 +83,7 @@ function makeEntry (data) {
 function createPage () {
   let container = $('#container-whole-doi')
   const url = getUrlByParameter('url')
-  $.getJSON(hostURL + 'services/context/papers?url=' + url, (response) => {
+  $.getJSON('https://' + hostBrowser + '-api.archive.org/' + 'services/context/papers?url=' + url, (response) => {
     $('.loader').hide()
     if (response.status && response.status === 'error') {
       $('#doi-heading').html(response.message)

--- a/webextension/scripts/domaintools.js
+++ b/webextension/scripts/domaintools.js
@@ -1,7 +1,7 @@
 // domaintools.js
 
 // from 'utils.js'
-/*   global getUrlByParameter */
+/*   global getUrlByParameter, hostBrowser */
 
 function appendToParent (id, item, text_before, parent, show_item, text_after) {
   if (item) {
@@ -15,7 +15,7 @@ function appendToParent (id, item, text_before, parent, show_item, text_after) {
 
 function get_domainTool () {
   let url = decodeURIComponent(getUrlByParameter('url'))
-  let domaintools_api = hostURL+'context/domaintools?url=' + url
+  let domaintools_api = 'https://' + hostBrowser + '-api.archive.org/' + 'context/domaintools?url=' + url
   $.getJSON(domaintools_api, (data) => {
     let parent = $('#show_domaintools_data')
     if (data.status !== 'error') {

--- a/webextension/scripts/overview.js
+++ b/webextension/scripts/overview.js
@@ -1,7 +1,7 @@
 // overview.js
 
 // from 'utils.js'
-/*   global getUrlByParameter, hostURL, getWaybackCount, timestampToDate */
+/*   global getUrlByParameter, hostBrowser, getWaybackCount, timestampToDate */
 
 function get_WBMSummary () {
   var url = decodeURIComponent(getUrlByParameter('url'))
@@ -12,7 +12,7 @@ function get_WBMSummary () {
 }
 
 function get_details (url) {
-  var new_url = hostURL + 'services/context/metadata?url=' + url
+  var new_url = 'https://' + hostBrowser + '-api.archive.org/' + 'services/context/metadata?url=' + url
   $.getJSON(new_url, (response) => {
     if ('type' in response) {
       var type = response.type
@@ -36,7 +36,7 @@ function get_details (url) {
 }
 
 function first_archive_details (url) {
-  var new_url = hostURL + 'cdx/search?url=' + url + '&limit=1&output=json'
+  var new_url = 'https://' + hostBrowser + '-api.archive.org/' + 'cdx/search?url=' + url + '&limit=1&output=json'
   $.getJSON(new_url, (data) => {
     if (data.length === 0) {
       $('#first_archive_datetime_error').text('URL has not been archived')
@@ -52,7 +52,7 @@ function first_archive_details (url) {
 }
 
 function recent_archive_details (url) {
-  var new_url = hostURL + 'cdx/search?url=' + url + '&limit=-1&output=json'
+  var new_url = 'https://' + hostBrowser + '-api.archive.org/' + 'cdx/search?url=' + url + '&limit=-1&output=json'
   $.getJSON(new_url, (data) => {
     if (data.length === 0) {
       $('#recent_archive_datetime_error').text('URL has not been archived')

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -1,7 +1,7 @@
 // popup.js
 
 // from 'utils.js'
-/*   global isValidUrl, makeValidURL, isNotExcludedUrl, get_clean_url, openByWindowSetting, hostURL */
+/*   global isValidUrl, makeValidURL, isNotExcludedUrl, get_clean_url, openByWindowSetting, hostBrowser */
 /*   global feedbackURL, newshosts, dateToTimestamp, searchValue */
 
 function homepage() {
@@ -23,7 +23,7 @@ function save_now() {
     }
     chrome.runtime.sendMessage({
       message: 'openurl',
-      wayback_url: hostURL + 'save/',
+      wayback_url: 'https://' + hostBrowser + '-api.archive.org/' + 'save/',
       page_url: url,
       options: options,
       method: 'save',
@@ -250,7 +250,7 @@ function arrow_key_access() {
 
 function display_list(key_word) {
   $('#suggestion-box').text('').hide()
-  $.getJSON(hostURL + '__wb/search/host?q=' + key_word, (data) => {
+  $.getJSON('https://' + hostBrowser + '-api.archive.org/' + '__wb/search/host?q=' + key_word, (data) => {
     $('#suggestion-box').text('').hide()
     if (data.hosts.length > 0 && $('#search-input').val() !== '') {
       $('#suggestion-box').show()
@@ -351,7 +351,7 @@ function borrow_books() {
               })
             } else {
               // if not, fetch it again
-              fetch(hostURL + 'services/context/amazonbooks?url=' + url)
+              fetch('https://' + hostBrowser + '-api.archive.org/' + 'services/context/amazonbooks?url=' + url)
               .then(res => res.json())
               .then(response => {
                 if (response['metadata'] && response['metadata']['identifier-access']) {

--- a/webextension/scripts/tagcloud.js
+++ b/webextension/scripts/tagcloud.js
@@ -1,5 +1,8 @@
 // tagcloud.js
 
+// from 'utils.js'
+/*   global hostBrowser */
+
 // from 'index.js'
 /*   global Levenshtein */
 
@@ -20,7 +23,7 @@ function get_tags (url) {
   var not_display3 = not_display4 + ' extension'
   var dontarray = ['view page', 'open', 'read more', not_display1, not_display2, not_display3, not_display4]
 
-  var new_url = hostURL+ 'services/context/tagcloud?url=' + toBeUsedAsURL
+  var new_url = 'https://' + hostBrowser + '-api.archive.org/' + 'services/context/tagcloud?url=' + toBeUsedAsURL
   $('#loader_tagcloud').show()
   fetch(new_url)
     .then(response => response.json())

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -58,15 +58,15 @@ function getBrowser() {
   else { return '' }
 }
 
-const hostURLs = {
-  chrome: 'https://chrome-api.archive.org/',
-  chromium: 'https://chrome-api.archive.org/',
-  firefox: 'https://firefox-api.archive.org/',
-  safari: 'https://safari-api.archive.org/',
-  brave: 'https://brave-api.archive.org/',
-  edge: 'https://edge-api.archive.org/',
-  ie: 'https://edge-api.archive.org/',
-  opera: 'https://opera-api.archive.org/'
+const hostBrowsers = {
+  chrome: 'chrome',
+  chromium: 'chrome',
+  firefox: 'firefox',
+  safari: 'safari',
+  brave: 'brave',
+  edge: 'edge',
+  ie: 'edge',
+  opera: 'opera'
 }
 
 const feedbackURLs = {
@@ -82,7 +82,7 @@ const isFirefox = (gBrowser === 'firefox')
 const isEdge = (gBrowser === 'edge')
 const isSafari = (gBrowser === 'safari')
 
-const hostURL = hostURLs[gBrowser] || hostURLs['chrome']
+const hostBrowser = hostBrowsers[gBrowser] || hostBrowsers['chrome']
 const feedbackURL = feedbackURLs[gBrowser] || '#'
 
 /* * * Wayback functions * * */
@@ -114,7 +114,7 @@ function badgeCountText(count) {
  */
 function getWaybackCount(url, onSuccess, onFail) {
   if (isValidUrl(url) && isNotExcludedUrl(url)) {
-    const requestUrl = hostURL + '__wb/sparkline'
+    const requestUrl = 'https://' + hostBrowser + '-api.archive.org/' + '__wb/sparkline'
     const requestParams = '?collection=web&output=json&url=' + encodeURIComponent(url)
     const timeoutPromise = new Promise((resolve, reject) => {
       setTimeout(() => {
@@ -154,7 +154,7 @@ function getWaybackCount(url, onSuccess, onFail) {
  * Checks Wayback Machine API for url snapshot
  */
 function wmAvailabilityCheck(url, onsuccess, onfail) {
-  var requestUrl = hostURL + 'wayback/available'
+  var requestUrl = 'https://' + hostBrowser + '-api.archive.org/' + 'wayback/available'
   var requestParams = 'url=' + encodeURIComponent(url)
   fetch(requestUrl, {
     method: 'POST',
@@ -478,7 +478,7 @@ if (typeof module !== 'undefined') {
     getWaybackCount,
     badgeCountText,
     isFirefox,
-    hostURL,
+    hostBrowser,
     timestampToDate,
     dateToTimestamp,
     viewableTimestamp,


### PR DESCRIPTION
We are currently detecting the browser and choosing API URLs dynamically, which looks like:

``` 
const hostURLs = {
   chrome: 'https://chrome-api.archive.org/',
   chromium: 'https://chrome-api.archive.org/',
   firefox: 'https://firefox-api.archive.org/',
   safari: 'https://safari-api.archive.org/',
   brave: 'https://brave-api.archive.org/',
   edge: 'https://edge-api.archive.org/',
   ie: 'https://edge-api.archive.org/',
   opera: 'https://opera-api.archive.org/'
 }
```

The API URL structure is the same for all browser, only the browser name is different, so, in this PR I have made an attempt to reduce the above to:

 ```
const hostBrowsers = {
   chrome: 'chrome',
   chromium: 'chrome',
   firefox: 'firefox',
   safari: 'safari',
   brave: 'brave',
   edge: 'edge',
   ie: 'edge',
   opera: 'opera'
 }
```